### PR TITLE
Add refresh token mechanism

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -15,4 +15,4 @@ emoji=true
 suppress_comment= \\(.\\|\n\\)*\\$FlowFixMe
 
 [version]
-0.102.0
+0.108.0

--- a/README.md
+++ b/README.md
@@ -76,9 +76,17 @@ const { refreshToken, ...result } = await client.auth.login(/* ... */);
 ```
 
 ### Set token (and refresh token)
-```
+```js
 client.setToken(token);
 client.setRefreshToken(refreshToken);
+```
+
+### Add an event when the token is refreshed
+
+```js
+client.setOnRefreshToken((newToken) => {
+  // Do something with the new token (like storing it in the localstorage...).
+});
 ```
 
 ### Log Out

--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ Depending on your environment you can import:
 const client = new WazoApiClient({
   server: 'demo.wazo.community', // required string
   agent: null // http(s).Agent instance, allows custom proxy, unsecured https, certificate etc.
+  clientId: null, // Set an identifier for your app when using refreshToken
 });
 ```
 
@@ -60,7 +61,7 @@ client.auth.logIn({
     tenants: [{ uuid }],
     auth_id
   },
-  token, // should be used for other request
+  // should be used for other request
   acls,
   utc_expires_at,
   xivo_uuid,
@@ -71,7 +72,13 @@ client.auth.logIn({
   xivo_user_uuid
 });
 // or
-const result = await client.auth.login(/* ... */);
+const { refreshToken, ...result } = await client.auth.login(/* ... */);
+```
+
+### Set token (and refresh token)
+```
+client.setToken(token);
+client.setRefreshToken(refreshToken);
 ```
 
 ### Log Out
@@ -91,61 +98,61 @@ const valid = await client.auth.checkToken(token);
 ### Other auth methods
 
 ```js
-client.auth.listTenants(token);
-client.auth.createTenant(token, name);
-client.auth.deleteTenant(token, uuid);
-client.auth.createUser(token, username, password, firstname, lastname);
-client.auth.addUserEmail(token, userUuid, email, main);
-client.auth.addUserPolicy(token, userUuid, policyUuid);
-client.auth.deleteUser(token);
-client.auth.listUsers(token);
-client.auth.listGroups(token);
-client.auth.createPolicy(token, name);
-client.auth.listPolicies(token);
+client.auth.listTenants();
+client.auth.createTenant(name);
+client.auth.deleteTenant(uuid);
+client.auth.createUser(username, password, firstname, lastname);
+client.auth.addUserEmail(userUuid, email, main);
+client.auth.addUserPolicy(userUuid, policyUuid);
+client.auth.deleteUser();
+client.auth.listUsers();
+client.auth.listGroups();
+client.auth.createPolicy(name);
+client.auth.listPolicies();
 ```
 
 ### Application
 ```js
-client.application.calls(token, applicationUuid); // list calls
-client.application.hangupCall(token, applicationUuid, callId); // hangup a call
-client.application.answerCall(token, applicationUuid, callId, context, exten, autoanswer);  // answer a call
-client.application.listNodes(token, applicationUuid); // list nodes
-client.application.listCallsNodes(token, applicationUuid, nodeUuid); // list calls in a node
-client.application.removeCallNodes(token, applicationUuid, nodeUuid, callId); // remove call from node (no hangup)
-client.application.addCallNodes(token, applicationUuid, nodeUuid, callId); // add call in a node
-client.application.playCall(token, applicationUuid, callId, language, uri); // play a sound into a call
+client.application.calls(applicationUuid); // list calls
+client.application.hangupCall(applicationUuid, callId); // hangup a call
+client.application.answerCall(applicationUuid, callId, context, exten, autoanswer);  // answer a call
+client.application.listNodes(applicationUuid); // list nodes
+client.application.listCallsNodes(applicationUuid, nodeUuid); // list calls in a node
+client.application.removeCallNodes(applicationUuid, nodeUuid, callId); // remove call from node (no hangup)
+client.application.addCallNodes(applicationUuid, nodeUuid, callId); // add call in a node
+client.application.playCall(applicationUuid, callId, language, uri); // play a sound into a call
 ```
 
 ### Calld
 ```js
-client.calld.getConferenceParticipantsAsUser(token, conferenceId); // List participants of a conference the user is part of
+client.calld.getConferenceParticipantsAsUser(conferenceId); // List participants of a conference the user is part of
 ```
 
 ### Confd
 ```js
-client.confd.listUsers(token);
-client.confd.getUser(token, userUuid);
-client.confd.getUserLineSip(token, userUuid, lineId);
-client.confd.listApplications(token);
+client.confd.listUsers();
+client.confd.getUser(userUuid);
+client.confd.getUserLineSip(userUuid, lineId);
+client.confd.listApplications();
 ```
 
 ### Dird
 ```js
-client.dird.search(token, context, term);
-client.dird.listPersonalContacts(token);
-client.dird.addContact(token, newContact);
-client.dird.editContact(token, contact);
-client.dird.deleteContact(token, contactUuid);
-client.dird.listFavorites(token, context);
-client.dird.markAsFavorite(token, source, sourceId);
-client.dird.removeFavorite(token, source, sourceId);
+client.dird.search(context, term);
+client.dird.listPersonalContacts();
+client.dird.addContact(newContact);
+client.dird.editContact(contact);
+client.dird.deleteContact(contactUuid);
+client.dird.listFavorites(context);
+client.dird.markAsFavorite(source, sourceId);
+client.dird.removeFavorite(source, sourceId);
 ```
 
 ### Call Logd
 ```js
-client.callLogd.search(token, search, limit);
-client.callLogd.listCallLogs(token, offset, limit);
-client.callLogd.listCallLogsFromDate(token, from, number);
+client.callLogd.search(search, limit);
+client.callLogd.listCallLogs(offset, limit);
+client.callLogd.listCallLogsFromDate(from, number);
 ```
 
 ### Calld
@@ -153,33 +160,33 @@ client.callLogd.listCallLogsFromDate(token, from, number);
 Please note, ctidNg endpoint is obsolete but continue to work with old version. Please update your code.
 
 ```js
-client.calld.answerSwitchboardQueuedCall(token, switchboardUuid, callId);
-client.calld.answerSwitchboardHeldCall(token switchboardUuid, callId);
-client.calld.cancelCall(token, callId);
-client.calld.deleteVoicemail(token, voicemailId);
-client.calld.fetchSwitchboardHeldCalls(token, switchboardUuid);
-client.calld.fetchSwitchboardQueuedCalls(token, switchboardUuid);
-client.calld.getConferenceParticipantsAsUser(token, conferenceId);
-client.calld.getPresence(token, contactUuid}; //deprecated use chatd in ctidNg, don't work with calld
-client.calld.getStatus(token, lineUuid); //deprecated use chatd in ctidNg, don't work with calld
-client.calld.holdSwitchboardCall(token, switchboardUuid, callId);
-client.calld.listCalls(token);
-client.calld.listMessages(token, participantUuid, limit);
-client.calld.listVoicemails(token);
-client.calld.makeCall(token, extension, fromMobile, lineId);
-client.calld.sendFax(token, extension, fax, callerId);
-client.calld.sendMessage(token, alias, msg, toUserId);
-client.calld.relocateCall(token, callId, destination, lineId);
-client.calld.updatePresence(token, presence);
+client.calld.answerSwitchboardQueuedCall(switchboardUuid, callId);
+client.calld.answerSwitchboardHeldCall(switchboardUuid, callId);
+client.calld.cancelCall(callId);
+client.calld.deleteVoicemail(voicemailId);
+client.calld.fetchSwitchboardHeldCalls(switchboardUuid);
+client.calld.fetchSwitchboardQueuedCalls(switchboardUuid);
+client.calld.getConferenceParticipantsAsUser(conferenceId);
+client.calld.getPresence(contactUuid); //deprecated use chatd in ctidNg, don't work with calld
+client.calld.getStatus(lineUuid); //deprecated use chatd in ctidNg, don't work with calld
+client.calld.holdSwitchboardCall(switchboardUuid, callId);
+client.calld.listCalls();
+client.calld.listMessages(participantUuid, limit);
+client.calld.listVoicemails();
+client.calld.makeCall(extension, fromMobile, lineId);
+client.calld.sendFax(extension, fax, callerId);
+client.calld.sendMessage(alias, msg, toUserId);
+client.calld.relocateCall(callId, destination, lineId);
+client.calld.updatePresence(presence);
 ```
 
 ### Accessd
 ```js
-client.accessd.listSubscriptions(token);
-client.accessd.createSubscription(token, { productSku, name, startDate, contractDate, autoRenew, term });
-client.accessd.getSubscription(token, uuid);
-client.accessd.listAuthorizations(token);
-client.accessd.getAuthorization(token, uuid);
+client.accessd.listSubscriptions();
+client.accessd.createSubscription({ productSku, name, startDate, contractDate, autoRenew, term });
+client.accessd.getSubscription(uuid);
+client.accessd.listAuthorizations();
+client.accessd.getAuthorization(uuid);
 ```
 
 ### WebRTCPhone
@@ -303,7 +310,7 @@ import { WazoWebSocketClient } from '@wazo/sdk';
 
 const ws = new WazoWebSocket({
   host, // wazo websocket host
-  token, // valid Wazo token
+  // valid Wazo token
 });
 
 // eventName can be on the of events here: http://documentation.wazo.community/en/stable/api_sdk/websocket.html

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wazo/sdk",
-  "version": "0.23.20",
+  "version": "0.24.0",
   "description": "Wazo's JavaScript Software Development Kit.",
   "main": "dist/wazo-sdk.js",
   "author": "Wazo (http://wazo.io)",

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "eslint-plugin-flowtype": "^3.11.1",
     "eslint-plugin-import": "^2.18.0",
     "eslint-plugin-prettier": "^3.1.0",
-    "flow-bin": "^0.102.0",
+    "flow-bin": "^0.108.0",
     "flow-typed": "^2.5.2",
     "jest": "^24.8.0",
     "jsonlint": "^1.6.3",

--- a/src/__tests__/api-client.test.js
+++ b/src/__tests__/api-client.test.js
@@ -56,7 +56,9 @@ const password = 'zowa';
 
 jest.mock('node-fetch/lib/index', () => {});
 
+const token = 1234;
 const client = new WazoApiClient({ server });
+client.setToken(token);
 
 describe('With correct API results', () => {
   beforeEach(() => {
@@ -88,10 +90,10 @@ describe('With correct API results', () => {
 
   describe('logOut test', () => {
     it('should delete the specified token', async () => {
-      const token = 123;
-      await client.auth.logOut(token);
+      const oldToken = 123;
+      await client.auth.logOut(oldToken);
 
-      expect(global.fetch).toBeCalledWith(`https://${server}/api/auth/${authVersion}/token/${token}`, {
+      expect(global.fetch).toBeCalledWith(`https://${server}/api/auth/${authVersion}/token/${oldToken}`, {
         method: 'delete',
         body: null,
         headers: {},
@@ -110,12 +112,12 @@ describe('With unAuthorized API results', () => {
 
   describe('checkLogin test', () => {
     it('should return false on 401 status', async () => {
-      const token = 123;
-      const result = await client.auth.checkToken(token);
+      const tokenToCheck = 123;
+      const result = await client.auth.checkToken(tokenToCheck);
 
       expect(result).toBeFalsy();
 
-      expect(global.fetch).toBeCalledWith(`https://${server}/api/auth/${authVersion}/token/${token}`, {
+      expect(global.fetch).toBeCalledWith(`https://${server}/api/auth/${authVersion}/token/${tokenToCheck}`, {
         method: 'head',
         body: null,
         headers: {},
@@ -134,11 +136,9 @@ describe('With not found API results', () => {
 
   describe('fetchVoicemail test', () => {
     it('should throw a BadResponse instance on 404 status', async () => {
-      const token = 123;
-
       let error = null;
       try {
-        await client.ctidNg.listVoicemails(token);
+        await client.ctidNg.listVoicemails();
       } catch (e) {
         error = e;
       }

--- a/src/api-client.js
+++ b/src/api-client.js
@@ -70,12 +70,21 @@ export default class ApiClient {
     this.initializeEndpoints();
   }
 
+  async forceRefreshToken() {
+    return this.refreshTokenCallback();
+  }
+
   async refreshTokenCallback() {
     if (!this.refreshToken) {
       return null;
     }
 
-    const { token } = await this.auth.refreshToken(this.refreshToken, this.refreshBackend, this.refreshExpiration);
+    const { token } = await this.auth.refreshToken(
+      this.refreshToken,
+      this.refreshBackend,
+      this.refreshExpiration,
+      true,
+    );
 
     if (this.onRefreshToken) {
       this.onRefreshToken(token);

--- a/src/api-client.js
+++ b/src/api-client.js
@@ -41,6 +41,9 @@ export default class ApiClient {
   calld: Object;
 
   refreshToken: ?string;
+  onRefreshToken: ?Function;
+  refreshExpiration: ?number;
+  refreshBackend: ?string;
 
   // @see https://github.com/facebook/flow/issues/183#issuecomment-358607052
   constructor({ server, agent = null, refreshToken, clientId }: ConstructorParams) {
@@ -72,7 +75,13 @@ export default class ApiClient {
       return null;
     }
 
-    const { token } = await this.auth.refreshToken(this.refreshToken);
+    const { token } = await this.auth.refreshToken(this.refreshToken, this.refreshBackend, this.refreshExpiration);
+
+    if (this.onRefreshToken) {
+      this.onRefreshToken(token);
+    }
+
+    this.setToken(token);
 
     return token;
   }
@@ -81,7 +90,23 @@ export default class ApiClient {
     this.client.token = token;
   }
 
-  setRefreshToken(refreshToken: string) {
+  setRefreshToken(refreshToken: ?string) {
     this.refreshToken = refreshToken;
+  }
+
+  setClientId(clientId: ?string) {
+    this.client.clientId = clientId;
+  }
+
+  setOnRefreshToken(onRefreshToken: Function) {
+    this.onRefreshToken = onRefreshToken;
+  }
+
+  setRefreshExpiration(refreshExpiration: number) {
+    this.refreshExpiration = refreshExpiration;
+  }
+
+  setRefreshBackend(refreshBackend: string) {
+    this.refreshBackend = refreshBackend;
   }
 }

--- a/src/api/accessd.js
+++ b/src/api/accessd.js
@@ -2,10 +2,9 @@
 import ApiRequester from '../utils/api-requester';
 
 export default (client: ApiRequester, baseUrl: string) => ({
-  listSubscriptions(token: string) {
-    return client.get(`${baseUrl}/subscriptions?recurse=true`, null, token);
-  },
-  createSubscription(token: string, { productSku, name, startDate, contractDate, autoRenew, term }: Object) {
+  listSubscriptions: () => client.get(`${baseUrl}/subscriptions?recurse=true`),
+
+  createSubscription: ({ productSku, name, startDate, contractDate, autoRenew, term }: Object) => {
     const body = {
       product_sku: productSku,
       name,
@@ -15,27 +14,25 @@ export default (client: ApiRequester, baseUrl: string) => ({
       term,
     };
 
-    return client.post(`${baseUrl}/subscriptions`, body, token);
+    return client.post(`${baseUrl}/subscriptions`, body);
   },
-  getSubscription(token: string, uuid: string) {
-    return client.get(`${baseUrl}/subscriptions/${uuid}`, null, token);
-  },
-  deleteSubscription(token: string, uuid: string) {
-    return client.delete(`${baseUrl}/subscriptions/${uuid}`, null, token);
-  },
-  createSubscriptionToken(token: string) {
-    return client.post(`${baseUrl}/subscriptions/token`, null, token);
-  },
-  listAuthorizations(token: string, subscriptionUuid: string) {
-    return client.get(`${baseUrl}/subscriptions/${subscriptionUuid}/authorizations`, null, token);
-  },
-  getAuthorization(token: string, subscriptionUuid: string, uuid: string) {
-    return client.get(`${baseUrl}/subscriptions/${subscriptionUuid}/authorizations/${uuid}`, null, token);
-  },
-  deleteAuthorization(token: string, subscriptionUuid: string, uuid: string) {
-    return client.delete(`${baseUrl}/subscriptions/${subscriptionUuid}/authorizations/${uuid}`, null, token);
-  },
-  createAuthorization(token: string, subscriptionUuid: string, { startDate, term, service, rules, autoRenew }: Object) {
+
+  getSubscription: (uuid: string) => client.get(`${baseUrl}/subscriptions/${uuid}`),
+
+  deleteSubscription: (uuid: string) => client.delete(`${baseUrl}/subscriptions/${uuid}`),
+
+  createSubscriptionToken: () => client.post(`${baseUrl}/subscriptions/token`),
+
+  listAuthorizations: (subscriptionUuid: string) =>
+    client.get(`${baseUrl}/subscriptions/${subscriptionUuid}/authorizations`),
+
+  getAuthorization: (subscriptionUuid: string, uuid: string) =>
+    client.get(`${baseUrl}/subscriptions/${subscriptionUuid}/authorizations/${uuid}`),
+
+  deleteAuthorization: (subscriptionUuid: string, uuid: string) =>
+    client.delete(`${baseUrl}/subscriptions/${subscriptionUuid}/authorizations/${uuid}`),
+
+  createAuthorization: (subscriptionUuid: string, { startDate, term, service, rules, autoRenew }: Object) => {
     const url = `${baseUrl}/subscriptions/${subscriptionUuid}/authorizations`;
     const body = {
       start_date: startDate,
@@ -45,6 +42,6 @@ export default (client: ApiRequester, baseUrl: string) => ({
       auto_renew: autoRenew,
     };
 
-    return client.post(url, body, token);
+    return client.post(url, body);
   },
 });

--- a/src/api/auth.js
+++ b/src/api/auth.js
@@ -68,7 +68,7 @@ export default (client: ApiRequester, baseUrl: string) => ({
       'Content-Type': 'application/json',
     };
 
-    return client.post(`${baseUrl}/token`, body, headers).then(response => Session.parse(response));
+    return client.post(`${baseUrl}/token`, body, headers, ApiRequester.defaultParser, false).then(Session.parse);
   },
 
   updatePassword: (userUuid: UUID, oldPassword: string, newPassword: string): Promise<Boolean> => {

--- a/src/api/call-logd.js
+++ b/src/api/call-logd.js
@@ -1,24 +1,14 @@
 /* @flow */
 import ApiRequester from '../utils/api-requester';
-import type { Token } from '../domain/types';
 import CallLog from '../domain/CallLog';
 
 export default (client: ApiRequester, baseUrl: string) => ({
-  search(token: Token, search: string, limit: number = 5): Promise<Array<CallLog>> {
-    return client
-      .get(`${baseUrl}/users/me/cdr`, { search, limit }, token)
-      .then(response => CallLog.parseMany(response));
-  },
+  search: (search: string, limit: number = 5): Promise<Array<CallLog>> =>
+    client.get(`${baseUrl}/users/me/cdr`, { search, limit }).then(CallLog.parseMany),
 
-  listCallLogs(token: Token, offset: number, limit: number = 5): Promise<Array<CallLog>> {
-    return client
-      .get(`${baseUrl}/users/me/cdr`, { offset, limit }, token)
-      .then(response => CallLog.parseMany(response));
-  },
+  listCallLogs: (offset: number, limit: number = 5): Promise<Array<CallLog>> =>
+    client.get(`${baseUrl}/users/me/cdr`, { offset, limit }).then(CallLog.parseMany),
 
-  listCallLogsFromDate(token: Token, from: Date, number: string): Promise<Array<CallLog>> {
-    return client
-      .get(`${baseUrl}/users/me/cdr`, { from: from.toISOString(), number }, token)
-      .then(response => CallLog.parseMany(response));
-  },
+  listCallLogsFromDate: (from: Date, number: string): Promise<Array<CallLog>> =>
+    client.get(`${baseUrl}/users/me/cdr`, { from: from.toISOString(), number }).then(CallLog.parseMany),
 });

--- a/src/api/calld.js
+++ b/src/api/calld.js
@@ -1,6 +1,6 @@
 /* @flow */
 import ApiRequester from '../utils/api-requester';
-import type { UUID, Token, RequestError } from '../domain/types';
+import type { UUID, RequestError } from '../domain/types';
 import type { ConferenceParticipants } from '../domain/Conference';
 import Relocation from '../domain/Relocation';
 import ChatMessage from '../domain/ChatMessage';
@@ -14,11 +14,10 @@ type CallQuery = {
 };
 
 export default (client: ApiRequester, baseUrl: string) => ({
-  updatePresence(token: Token, presence: string): Promise<Boolean> {
-    return client.put(`${baseUrl}/users/me/presences`, { presence }, token, ApiRequester.successResponseParser);
-  },
+  updatePresence: (presence: string): Promise<Boolean> =>
+    client.put(`${baseUrl}/users/me/presences`, { presence }, null, ApiRequester.successResponseParser),
 
-  listMessages(token: Token, participantUuid: ?UUID, limit?: number): Promise<Array<ChatMessage>> {
+  listMessages: (participantUuid: ?UUID, limit?: number): Promise<Array<ChatMessage>> => {
     const query: Object = {};
 
     if (participantUuid) {
@@ -29,16 +28,16 @@ export default (client: ApiRequester, baseUrl: string) => ({
       query.limit = limit;
     }
 
-    return client.get(`${baseUrl}/users/me/chats`, query, token).then(response => ChatMessage.parseMany(response));
+    return client.get(`${baseUrl}/users/me/chats`, query).then(response => ChatMessage.parseMany(response));
   },
 
-  sendMessage(token: Token, alias: string, msg: string, toUserId: string) {
+  sendMessage: (alias: string, msg: string, toUserId: string) => {
     const body = { alias, msg, to: toUserId };
 
-    return client.post(`${baseUrl}/users/me/chats`, body, token, ApiRequester.successResponseParser);
+    return client.post(`${baseUrl}/users/me/chats`, body, null, ApiRequester.successResponseParser);
   },
 
-  makeCall(token: Token, extension: string, fromMobile: boolean, lineId: ?number) {
+  makeCall: (extension: string, fromMobile: boolean, lineId: ?number) => {
     const query: CallQuery = {
       from_mobile: fromMobile,
       extension,
@@ -47,24 +46,16 @@ export default (client: ApiRequester, baseUrl: string) => ({
     if (lineId) {
       query.line_id = lineId;
     }
-    return client.post(`${baseUrl}/users/me/calls`, query, token);
+
+    return client.post(`${baseUrl}/users/me/calls`, query);
   },
 
-  cancelCall(token: Token, callId: number): Promise<Boolean> {
-    return client.delete(`${baseUrl}/users/me/calls/${callId}`, null, token);
-  },
+  cancelCall: (callId: number): Promise<Boolean> => client.delete(`${baseUrl}/users/me/calls/${callId}`, null),
 
-  listCalls(token: Token): Promise<Array<Call>> {
-    return client.get(`${baseUrl}/users/me/calls`, null, token).then(response => Call.parseMany(response.items));
-  },
+  listCalls: (): Promise<Array<Call>> =>
+    client.get(`${baseUrl}/users/me/calls`, null).then(response => Call.parseMany(response.items)),
 
-  relocateCall(
-    token: Token,
-    callId: number,
-    destination: string,
-    lineId: ?number,
-    contact?: ?string,
-  ): Promise<Relocation> {
+  relocateCall(callId: number, destination: string, lineId: ?number, contact?: ?string): Promise<Relocation> {
     const body: Object = {
       completions: ['answer'],
       destination,
@@ -83,52 +74,45 @@ export default (client: ApiRequester, baseUrl: string) => ({
       body.location.contact = contact;
     }
 
-    return client.post(`${baseUrl}/users/me/relocates`, body, token).then(response => Relocation.parse(response));
+    return client.post(`${baseUrl}/users/me/relocates`, body).then(response => Relocation.parse(response));
   },
 
-  listVoicemails(token: Token): Promise<RequestError | Array<Voicemail>> {
-    return client.get(`${baseUrl}/users/me/voicemails`, null, token).then(response => Voicemail.parseMany(response));
-  },
+  listVoicemails: (): Promise<RequestError | Array<Voicemail>> =>
+    client.get(`${baseUrl}/users/me/voicemails`).then(response => Voicemail.parseMany(response)),
 
-  deleteVoicemail(token: Token, voicemailId: number): Promise<Boolean> {
-    return client.delete(`${baseUrl}/users/me/voicemails/messages/${voicemailId}`, null, token);
-  },
+  deleteVoicemail: (voicemailId: number): Promise<Boolean> =>
+    client.delete(`${baseUrl}/users/me/voicemails/messages/${voicemailId}`),
 
-  fetchSwitchboardHeldCalls(token: Token, switchboardUuid: UUID) {
-    return client.get(`${baseUrl}/switchboards/${switchboardUuid}/calls/held`, null, token);
-  },
+  fetchSwitchboardHeldCalls: (switchboardUuid: UUID) =>
+    client.get(`${baseUrl}/switchboards/${switchboardUuid}/calls/held`),
 
-  holdSwitchboardCall(token: Token, switchboardUuid: UUID, callId: string) {
-    return client.put(
+  holdSwitchboardCall: (switchboardUuid: UUID, callId: string) =>
+    client.put(
       `${baseUrl}/switchboards/${switchboardUuid}/calls/held/${callId}`,
       null,
-      token,
+      null,
       ApiRequester.successResponseParser,
-    );
-  },
+    ),
 
-  answerSwitchboardHeldCall(token: Token, switchboardUuid: UUID, callId: string) {
-    return client.put(`${baseUrl}/switchboards/${switchboardUuid}/calls/held/${callId}/answer`, null, token);
-  },
+  answerSwitchboardHeldCall: (switchboardUuid: UUID, callId: string) =>
+    client.put(`${baseUrl}/switchboards/${switchboardUuid}/calls/held/${callId}/answer`),
 
-  fetchSwitchboardQueuedCalls(token: Token, switchboardUuid: UUID) {
-    return client.get(`${baseUrl}/switchboards/${switchboardUuid}/calls/queued`, null, token);
-  },
+  fetchSwitchboardQueuedCalls: (switchboardUuid: UUID) =>
+    client.get(`${baseUrl}/switchboards/${switchboardUuid}/calls/queued`),
 
-  answerSwitchboardQueuedCall(token: Token, switchboardUuid: UUID, callId: string) {
-    return client.put(`${baseUrl}/switchboards/${switchboardUuid}/calls/queued/${callId}/answer`, null, token);
-  },
+  answerSwitchboardQueuedCall: (switchboardUuid: UUID, callId: string) =>
+    client.put(`${baseUrl}/switchboards/${switchboardUuid}/calls/queued/${callId}/answer`),
 
-  sendFax(token: Token, extension: string, fax: string, callerId: ?string = null) {
+  sendFax: (extension: string, fax: string, callerId: ?string = null) => {
     const headers = {
       'Content-type': 'application/pdf',
-      'X-Auth-Token': token,
+      'X-Auth-Token': client.token,
     };
     const params = ApiRequester.getQueryString({ extension, caller_id: callerId });
 
     return client.post(`${baseUrl}/users/me/faxes?${params}`, fax, headers);
   },
 
-  getConferenceParticipantsAsUser: async (token: Token, conferenceId: string): Promise<ConferenceParticipants> =>
-    client.get(`${baseUrl}/users/me/conferences/${conferenceId}/participants`, null, token),
+  getConferenceParticipantsAsUser: async (conferenceId: string): Promise<ConferenceParticipants> =>
+    client.get(`${baseUrl}/users/me/conferences/${conferenceId}/participants`),
 });

--- a/src/api/chatd.js
+++ b/src/api/chatd.js
@@ -1,6 +1,6 @@
 /* @flow */
 import ApiRequester from '../utils/api-requester';
-import type { UUID, Token } from '../domain/types';
+import type { UUID } from '../domain/types';
 import Profile from '../domain/Profile';
 import ChatRoom from '../domain/ChatRoom';
 import type { ChatUser, ChatMessageListResponse } from '../domain/ChatMessage';
@@ -29,47 +29,44 @@ type GetMessagesOptions = {
 };
 
 export default (client: ApiRequester, baseUrl: string) => ({
-  updateState: (token: Token, contactUuid: UUID, state: string): Promise<Boolean> =>
-    client.put(`${baseUrl}/users/${contactUuid}/presences`, { state }, token, ApiRequester.successResponseParser),
+  updateState: (contactUuid: UUID, state: string): Promise<Boolean> =>
+    client.put(`${baseUrl}/users/${contactUuid}/presences`, { state }, null, ApiRequester.successResponseParser),
 
-  updateStatus: (token: Token, contactUuid: UUID, state: string, status: string): Promise<Boolean> => {
+  updateStatus: (contactUuid: UUID, state: string, status: string): Promise<Boolean> => {
     const body = { state, status };
 
-    return client.put(`${baseUrl}/users/${contactUuid}/presences`, body, token, ApiRequester.successResponseParser);
+    return client.put(`${baseUrl}/users/${contactUuid}/presences`, body, null, ApiRequester.successResponseParser);
   },
 
-  getState: async (token: Token, contactUuid: UUID): Promise<string> =>
-    client
-      .get(`${baseUrl}/users/${contactUuid}/presences`, null, token)
-      .then((response: PresenceResponse) => response.state),
+  getState: async (contactUuid: UUID): Promise<string> =>
+    client.get(`${baseUrl}/users/${contactUuid}/presences`).then((response: PresenceResponse) => response.state),
 
-  getContactStatusInfo: async (token: Token, contactUuid: UUID): Promise<PresenceResponse> =>
-    client.get(`${baseUrl}/users/${contactUuid}/presences`, null, token).then((response: PresenceResponse) => response),
+  getContactStatusInfo: async (contactUuid: UUID): Promise<PresenceResponse> =>
+    client.get(`${baseUrl}/users/${contactUuid}/presences`).then((response: PresenceResponse) => response),
 
-  getLineState: async (token: Token, contactUuid: UUID): Promise<string> =>
+  getLineState: async (contactUuid: UUID): Promise<string> =>
     client
-      .get(`${baseUrl}/users/${contactUuid}/presences`, null, token)
+      .get(`${baseUrl}/users/${contactUuid}/presences`)
       .then((response: PresenceResponse) => Profile.getLinesState(response.lines)),
 
-  getMultipleLineState: async (token: Token, contactUuids: Array<UUID>): Promise<string> =>
+  getMultipleLineState: async (contactUuids: Array<UUID>): Promise<string> =>
     client
-      .get(`${baseUrl}/users/presences`, { user_uuid: contactUuids.join(',') }, token)
+      .get(`${baseUrl}/users/presences`, { user_uuid: contactUuids.join(',') })
       .then((response: PresenceListResponse) => response.items),
 
-  getUserRooms: async (token: Token): Promise<Array<ChatRoom>> =>
-    client.get(`${baseUrl}/users/me/rooms`, null, token).then(ChatRoom.parseMany),
+  getUserRooms: async (): Promise<Array<ChatRoom>> => client.get(`${baseUrl}/users/me/rooms`).then(ChatRoom.parseMany),
 
-  createRoom: async (token: Token, name: string, users: Array<ChatUser>): Promise<ChatRoom> =>
-    client.post(`${baseUrl}/users/me/rooms`, { name, users }, token).then(ChatRoom.parse),
+  createRoom: async (name: string, users: Array<ChatUser>): Promise<ChatRoom> =>
+    client.post(`${baseUrl}/users/me/rooms`, { name, users }).then(ChatRoom.parse),
 
-  getRoomMessages: async (token: Token, roomUuid: string): Promise<Array<ChatMessage>> =>
+  getRoomMessages: async (roomUuid: string): Promise<Array<ChatMessage>> =>
     client
-      .get(`${baseUrl}/users/me/rooms/${roomUuid}/messages`, null, token)
+      .get(`${baseUrl}/users/me/rooms/${roomUuid}/messages`)
       .then((response: ChatMessageListResponse) => ChatMessage.parseMany(response)),
 
-  sendRoomMessage: async (token: Token, roomUuid: string, message: ChatMessage): Promise<ChatMessage> =>
-    client.post(`${baseUrl}/users/me/rooms/${roomUuid}/messages`, message, token).then(ChatMessage.parse),
+  sendRoomMessage: async (roomUuid: string, message: ChatMessage): Promise<ChatMessage> =>
+    client.post(`${baseUrl}/users/me/rooms/${roomUuid}/messages`, message).then(ChatMessage.parse),
 
-  getMessages: async (token: Token, options: GetMessagesOptions): Promise<ChatMessage> =>
-    client.get(`${baseUrl}/users/me/rooms/messages`, options, token),
+  getMessages: async (options: GetMessagesOptions): Promise<ChatMessage> =>
+    client.get(`${baseUrl}/users/me/rooms/messages`, options),
 });

--- a/src/api/confd.js
+++ b/src/api/confd.js
@@ -1,6 +1,6 @@
 /* @flow */
 import ApiRequester from '../utils/api-requester';
-import type { UUID, Token, ListConfdUsersResponse, ListApplicationsResponse } from '../domain/types';
+import type { UUID, ListConfdUsersResponse, ListApplicationsResponse } from '../domain/types';
 import Profile from '../domain/Profile';
 import SipLine from '../domain/SipLine';
 
@@ -28,26 +28,25 @@ export default (client: ApiRequester, baseUrl: string) => ({
   updateDoNotDisturb: (userUuid: UUID, enabled: Boolean): Promise<Boolean> =>
     client.put(`${baseUrl}/users/${userUuid}/services/dnd`, { enabled }, null, ApiRequester.successResponseParser),
 
-  // @TODO: type response
   getUserLineSip: (userUuid: string, lineId: string): Promise<SipLine> =>
-    client.get(`${baseUrl}/users/${userUuid}/lines/${lineId}/associated/endpoints/sip`, null).then(SipLine.parse),
+    client.get(`${baseUrl}/users/${userUuid}/lines/${lineId}/associated/endpoints/sip`).then(SipLine.parse),
 
-  getUserLinesSip: (userUuid: string, lineIds: string[]): Promise<SipLine>[] =>
+  getUserLinesSip(userUuid: string, lineIds: string[]): Promise<SipLine>[] {
     // $FlowFixMe
-    Promise.all(lineIds.map(lineId => this.getUserLineSip(client.token, userUuid, lineId))),
+    return Promise.all(lineIds.map(lineId => this.getUserLineSip(userUuid, lineId)));
+  },
 
-  getUserLineSipFromToken: (token: Token, userUuid: string) =>
-    // $FlowFixMe
-    this.getUser(token, userUuid).then(user => {
+  getUserLineSipFromToken(userUuid: string) {
+    return this.getUser(userUuid).then(user => {
       if (!user.lines.length) {
         console.warn(`No sip line for user: ${userUuid}`);
         return null;
       }
       const line = user.lines[0];
 
-      // $FlowFixMe
-      return this.getUserLineSip(token, userUuid, line.id);
-    }),
+      return this.getUserLineSip(userUuid, line.id);
+    });
+  },
 
   listApplications: (): Promise<ListApplicationsResponse> => client.get(`${baseUrl}/applications?recurse=true`, null),
 

--- a/src/api/confd.js
+++ b/src/api/confd.js
@@ -1,19 +1,15 @@
 /* @flow */
 import ApiRequester from '../utils/api-requester';
-import type { UUID, Token, ListConfdUsersResponse, ListApplicationsResponse, WebRtcConfig } from '../domain/types';
+import type { UUID, Token, ListConfdUsersResponse, ListApplicationsResponse } from '../domain/types';
 import Profile from '../domain/Profile';
 import SipLine from '../domain/SipLine';
 
 export default (client: ApiRequester, baseUrl: string) => ({
-  listUsers(token: Token): Promise<ListConfdUsersResponse> {
-    return client.get(`${baseUrl}/users`, null, token);
-  },
+  listUsers: (): Promise<ListConfdUsersResponse> => client.get(`${baseUrl}/users`, null),
 
-  getUser(token: Token, userUuid: string): Promise<Profile> {
-    return client.get(`${baseUrl}/users/${userUuid}`, null, token).then(response => Profile.parse(response));
-  },
+  getUser: (userUuid: string): Promise<Profile> => client.get(`${baseUrl}/users/${userUuid}`, null).then(Profile.parse),
 
-  updateUser(token: Token, userUuid: string, profile: Profile): Promise<Boolean> {
+  updateUser: (userUuid: string, profile: Profile): Promise<Boolean> => {
     const body = {
       firstname: profile.firstName,
       lastname: profile.lastName,
@@ -21,62 +17,39 @@ export default (client: ApiRequester, baseUrl: string) => ({
       mobile_phone_number: profile.mobileNumber,
     };
 
-    return client.put(`${baseUrl}/users/${userUuid}`, body, token, ApiRequester.successResponseParser);
+    return client.put(`${baseUrl}/users/${userUuid}`, body, null, ApiRequester.successResponseParser);
   },
 
-  updateForwardOption(
-    token: Token,
-    userUuid: string,
-    key: string,
-    destination: string,
-    enabled: Boolean,
-  ): Promise<Boolean> {
+  updateForwardOption: (userUuid: string, key: string, destination: string, enabled: Boolean): Promise<Boolean> => {
     const url = `${baseUrl}/users/${userUuid}/forwards/${key}`;
-    return client.put(url, { destination, enabled }, token, ApiRequester.successResponseParser);
+    return client.put(url, { destination, enabled }, null, ApiRequester.successResponseParser);
   },
 
-  updateDoNotDisturb(token: Token, userUuid: UUID, enabled: Boolean): Promise<Boolean> {
-    const url = `${baseUrl}/users/${userUuid}/services/dnd`;
-
-    return client.put(url, { enabled }, token, ApiRequester.successResponseParser);
-  },
+  updateDoNotDisturb: (userUuid: UUID, enabled: Boolean): Promise<Boolean> =>
+    client.put(`${baseUrl}/users/${userUuid}/services/dnd`, { enabled }, null, ApiRequester.successResponseParser),
 
   // @TODO: type response
-  getUserLineSip(token: Token, userUuid: string, lineId: string): Promise<SipLine> {
-    return client
-      .get(`${baseUrl}/users/${userUuid}/lines/${lineId}/associated/endpoints/sip`, null, token)
-      .then(response => SipLine.parse(response));
-  },
+  getUserLineSip: (userUuid: string, lineId: string): Promise<SipLine> =>
+    client.get(`${baseUrl}/users/${userUuid}/lines/${lineId}/associated/endpoints/sip`, null).then(SipLine.parse),
 
-  getUserLinesSip(token: Token, userUuid: string, lineIds: string[]): Promise<SipLine>[] {
+  getUserLinesSip: (userUuid: string, lineIds: string[]): Promise<SipLine>[] =>
     // $FlowFixMe
-    return Promise.all(lineIds.map(lineId => this.getUserLineSip(token, userUuid, lineId)));
-  },
+    Promise.all(lineIds.map(lineId => this.getUserLineSip(client.token, userUuid, lineId))),
 
-  getUserLineSipFromToken(token: Token, userUuid: string) {
-    return this.getUser(token, userUuid).then(user => {
+  getUserLineSipFromToken: (token: Token, userUuid: string) =>
+    // $FlowFixMe
+    this.getUser(token, userUuid).then(user => {
       if (!user.lines.length) {
         console.warn(`No sip line for user: ${userUuid}`);
         return null;
       }
       const line = user.lines[0];
 
+      // $FlowFixMe
       return this.getUserLineSip(token, userUuid, line.id);
-    });
-  },
+    }),
 
-  listApplications(token: Token): Promise<ListApplicationsResponse> {
-    const url = `${baseUrl}/applications?recurse=true`;
+  listApplications: (): Promise<ListApplicationsResponse> => client.get(`${baseUrl}/applications?recurse=true`, null),
 
-    return client.get(url, null, token);
-  },
-
-  getSIP(token: Token, userUuid: UUID, lineId: number): Promise<WebRtcConfig> {
-    console.warn('`confd.getSIP` is deprecated, use getUserLineSip instead');
-    return client.get(`${baseUrl}/users/${userUuid}/lines/${lineId}/associated/endpoints/sip`, null, token);
-  },
-
-  getInfos(token: Token): Promise<{ uuid: string, wazo_version: string }> {
-    return client.get(`${baseUrl}/infos`, null, token);
-  },
+  getInfos: (): Promise<{ uuid: string, wazo_version: string }> => client.get(`${baseUrl}/infos`, null),
 });

--- a/src/api/ctid-ng.js
+++ b/src/api/ctid-ng.js
@@ -1,6 +1,6 @@
 /* @flow */
 import ApiRequester from '../utils/api-requester';
-import type { UUID, Token, RequestError } from '../domain/types';
+import type { UUID, RequestError } from '../domain/types';
 import Relocation from '../domain/Relocation';
 import ChatMessage from '../domain/ChatMessage';
 import Voicemail from '../domain/Voicemail';
@@ -13,11 +13,10 @@ type CallQuery = {
 };
 
 export default (client: ApiRequester, baseUrl: string) => ({
-  updatePresence(token: Token, presence: string): Promise<Boolean> {
-    return client.put(`${baseUrl}/users/me/presences`, { presence }, token, ApiRequester.successResponseParser);
-  },
+  updatePresence: (presence: string): Promise<Boolean> =>
+    client.put(`${baseUrl}/users/me/presences`, { presence }, null, ApiRequester.successResponseParser),
 
-  listMessages(token: Token, participantUuid: ?UUID, limit?: number): Promise<Array<ChatMessage>> {
+  listMessages: (participantUuid: ?UUID, limit?: number): Promise<Array<ChatMessage>> => {
     const query: Object = {};
 
     if (participantUuid) {
@@ -28,16 +27,16 @@ export default (client: ApiRequester, baseUrl: string) => ({
       query.limit = limit;
     }
 
-    return client.get(`${baseUrl}/users/me/chats`, query, token).then(response => ChatMessage.parseMany(response));
+    return client.get(`${baseUrl}/users/me/chats`, query).then(ChatMessage.parseMany);
   },
 
-  sendMessage(token: Token, alias: string, msg: string, toUserId: string) {
+  sendMessage: (alias: string, msg: string, toUserId: string) => {
     const body = { alias, msg, to: toUserId };
 
-    return client.post(`${baseUrl}/users/me/chats`, body, token, ApiRequester.successResponseParser);
+    return client.post(`${baseUrl}/users/me/chats`, body, null, ApiRequester.successResponseParser);
   },
 
-  makeCall(token: Token, extension: string, fromMobile: boolean, lineId: ?number) {
+  makeCall: (extension: string, fromMobile: boolean, lineId: ?number) => {
     const query: CallQuery = {
       from_mobile: fromMobile,
       extension,
@@ -46,24 +45,15 @@ export default (client: ApiRequester, baseUrl: string) => ({
     if (lineId) {
       query.line_id = lineId;
     }
-    return client.post(`${baseUrl}/users/me/calls`, query, token);
+    return client.post(`${baseUrl}/users/me/calls`, query);
   },
 
-  cancelCall(token: Token, callId: number): Promise<Boolean> {
-    return client.delete(`${baseUrl}/users/me/calls/${callId}`, null, token);
-  },
+  cancelCall: (callId: number): Promise<Boolean> => client.delete(`${baseUrl}/users/me/calls/${callId}`),
 
-  listCalls(token: Token): Promise<Array<Call>> {
-    return client.get(`${baseUrl}/users/me/calls`, null, token).then(response => Call.parseMany(response.items));
-  },
+  listCalls: (): Promise<Array<Call>> =>
+    client.get(`${baseUrl}/users/me/calls`).then(response => Call.parseMany(response.items)),
 
-  relocateCall(
-    token: Token,
-    callId: number,
-    destination: string,
-    lineId: ?number,
-    contact?: ?string,
-  ): Promise<Relocation> {
+  relocateCall(callId: number, destination: string, lineId: ?number, contact?: ?string): Promise<Relocation> {
     const body: Object = {
       completions: ['answer'],
       destination,
@@ -82,54 +72,44 @@ export default (client: ApiRequester, baseUrl: string) => ({
       body.location.contact = contact;
     }
 
-    return client.post(`${baseUrl}/users/me/relocates`, body, token).then(response => Relocation.parse(response));
+    return client.post(`${baseUrl}/users/me/relocates`, body).then(response => Relocation.parse(response));
   },
 
-  listVoicemails(token: Token): Promise<RequestError | Array<Voicemail>> {
-    return client.get(`${baseUrl}/users/me/voicemails`, null, token).then(response => Voicemail.parseMany(response));
-  },
+  listVoicemails: (): Promise<RequestError | Array<Voicemail>> =>
+    client.get(`${baseUrl}/users/me/voicemails`, null).then(response => Voicemail.parseMany(response)),
 
-  deleteVoicemail(token: Token, voicemailId: number): Promise<Boolean> {
-    return client.delete(`${baseUrl}/users/me/voicemails/messages/${voicemailId}`, null, token);
-  },
+  deleteVoicemail: (voicemailId: number): Promise<Boolean> =>
+    client.delete(`${baseUrl}/users/me/voicemails/messages/${voicemailId}`, null),
 
-  getPresence(token: Token, contactUuid: UUID): Promise<{ presence: string, user_uuid: string, xivo_uuid: string }> {
-    return client.get(`${baseUrl}/users/${contactUuid}/presences`, null, token);
-  },
+  getPresence: (contactUuid: UUID): Promise<{ presence: string, user_uuid: string, xivo_uuid: string }> =>
+    client.get(`${baseUrl}/users/${contactUuid}/presences`, null),
 
-  getStatus(token: Token, lineUuid: UUID) {
-    return client.get(`${baseUrl}/lines/${lineUuid}/presences`, null, token);
-  },
+  getStatus: (lineUuid: UUID) => client.get(`${baseUrl}/lines/${lineUuid}/presences`, null),
 
-  fetchSwitchboardHeldCalls(token: Token, switchboardUuid: UUID) {
-    return client.get(`${baseUrl}/switchboards/${switchboardUuid}/calls/held`, null, token);
-  },
+  fetchSwitchboardHeldCalls: (switchboardUuid: UUID) =>
+    client.get(`${baseUrl}/switchboards/${switchboardUuid}/calls/held`, null),
 
-  holdSwitchboardCall(token: Token, switchboardUuid: UUID, callId: string) {
-    return client.put(
+  holdSwitchboardCall: (switchboardUuid: UUID, callId: string) =>
+    client.put(
       `${baseUrl}/switchboards/${switchboardUuid}/calls/held/${callId}`,
       null,
-      token,
+      null,
       ApiRequester.successResponseParser,
-    );
-  },
+    ),
 
-  answerSwitchboardHeldCall(token: Token, switchboardUuid: UUID, callId: string) {
-    return client.put(`${baseUrl}/switchboards/${switchboardUuid}/calls/held/${callId}/answer`, null, token);
-  },
+  answerSwitchboardHeldCall: (switchboardUuid: UUID, callId: string) =>
+    client.put(`${baseUrl}/switchboards/${switchboardUuid}/calls/held/${callId}/answer`, null),
 
-  fetchSwitchboardQueuedCalls(token: Token, switchboardUuid: UUID) {
-    return client.get(`${baseUrl}/switchboards/${switchboardUuid}/calls/queued`, null, token);
-  },
+  fetchSwitchboardQueuedCalls: (switchboardUuid: UUID) =>
+    client.get(`${baseUrl}/switchboards/${switchboardUuid}/calls/queued`, null),
 
-  answerSwitchboardQueuedCall(token: Token, switchboardUuid: UUID, callId: string) {
-    return client.put(`${baseUrl}/switchboards/${switchboardUuid}/calls/queued/${callId}/answer`, null, token);
-  },
+  answerSwitchboardQueuedCall: (switchboardUuid: UUID, callId: string) =>
+    client.put(`${baseUrl}/switchboards/${switchboardUuid}/calls/queued/${callId}/answer`, null),
 
-  sendFax(token: Token, extension: string, fax: string, callerId: ?string = null) {
+  sendFax: (extension: string, fax: string, callerId: ?string = null) => {
     const headers = {
       'Content-type': 'application/pdf',
-      'X-Auth-Token': token,
+      'X-Auth-Token': null,
     };
     const params = ApiRequester.getQueryString({ extension, caller_id: callerId });
 

--- a/src/domain/Phone/CTIPhone.js
+++ b/src/domain/Phone/CTIPhone.js
@@ -12,16 +12,13 @@ import CallApi from '../../service/CallApi';
 export default class CTIPhone extends Emitter implements Phone {
   session: Session;
 
-  server: string;
-
   isMobile: boolean;
 
   currentCall: ?Call;
 
-  constructor(server: string, session: Session, isMobile: boolean = false) {
+  constructor(session: Session, isMobile: boolean = false) {
     super();
     this.session = session;
-    this.server = server;
     this.isMobile = isMobile;
   }
 
@@ -52,7 +49,7 @@ export default class CTIPhone extends Emitter implements Phone {
       return null;
     }
     try {
-      this.currentCall = await CallApi.makeCall(this.server, line, number, this.isMobile);
+      this.currentCall = await CallApi.makeCall(line, number, this.isMobile);
     } catch (_) {
       // We have to deal with error like `User has no mobile phone number` error in the UI.
     }
@@ -80,7 +77,7 @@ export default class CTIPhone extends Emitter implements Phone {
 
   async hangup(callSession: CallSession): Promise<void> {
     try {
-      await CallApi.cancelCall(this.server, this.session, callSession);
+      await CallApi.cancelCall(callSession);
       if (this.currentCall && callSession.callId === this.currentCall.id) {
         this.endCurrentCall(callSession);
       }
@@ -92,7 +89,7 @@ export default class CTIPhone extends Emitter implements Phone {
   }
 
   async reject(callSession: CallSession): Promise<void> {
-    await CallApi.cancelCall(this.server, this.session, callSession);
+    await CallApi.cancelCall(callSession);
     this.eventEmitter.emit('onCallEnded', callSession);
   }
 

--- a/src/domain/Phone/CTIPhone.js
+++ b/src/domain/Phone/CTIPhone.js
@@ -52,7 +52,7 @@ export default class CTIPhone extends Emitter implements Phone {
       return null;
     }
     try {
-      this.currentCall = await CallApi.makeCall(this.server, this.session, line, number, this.isMobile);
+      this.currentCall = await CallApi.makeCall(this.server, line, number, this.isMobile);
     } catch (_) {
       // We have to deal with error like `User has no mobile phone number` error in the UI.
     }

--- a/src/domain/Session.js
+++ b/src/domain/Session.js
@@ -16,6 +16,7 @@ const MINIMUM_WAZO_ENGINE_VERSION_FOR_DEFAULT_CONTEXT = '19.08';
 type Response = {
   data: {
     token: Token,
+    refresh_token?: Token,
     acls: Array<string>,
     utc_expires_at: string,
     xivo_uuid: string,
@@ -45,6 +46,7 @@ type Authorization = {
 
 type SessionArguments = {
   token: string,
+  refreshToken?: ?string,
   uuid?: ?string,
   tenantUuid?: ?string,
   profile?: ?Profile,
@@ -55,6 +57,7 @@ type SessionArguments = {
 
 export default class Session {
   token: string;
+  refreshToken: ?string;
   uuid: ?string;
   tenantUuid: ?string;
   engineVersion: ?string;
@@ -77,6 +80,7 @@ export default class Session {
 
     return new Session({
       token: plain.data.token,
+      refreshToken: plain.data.refresh_token || null,
       uuid: plain.data.metadata ? plain.data.metadata.uuid : null,
       authorizations,
       tenantUuid: plain.data.metadata ? plain.data.metadata.tenant_uuid : undefined,
@@ -88,7 +92,16 @@ export default class Session {
     return newFrom(profile, Session);
   }
 
-  constructor({ token, uuid, tenantUuid, profile, expiresAt, authorizations, engineVersion }: SessionArguments = {}) {
+  constructor({
+    token,
+    uuid,
+    tenantUuid,
+    profile,
+    expiresAt,
+    authorizations,
+    engineVersion,
+    refreshToken,
+  }: SessionArguments = {}) {
     this.token = token;
     this.uuid = uuid;
     this.tenantUuid = tenantUuid || null;
@@ -96,6 +109,7 @@ export default class Session {
     this.expiresAt = expiresAt;
     this.authorizations = authorizations || [];
     this.engineVersion = engineVersion;
+    this.refreshToken = refreshToken;
   }
 
   hasExpired(date: Date = new Date()): boolean {

--- a/src/domain/__tests__/Session.test.js
+++ b/src/domain/__tests__/Session.test.js
@@ -60,6 +60,7 @@ describe('Session domain', () => {
     expect(session).toEqual(
       new Session({
         token: 'b93ae6bd-08d7-4001-9e61-057e72bbc4b3',
+        refreshToken: null,
         uuid: 'a14dd6d6-547c-434d-bd5c-e882b5b83b54',
         expiresAt: new Date('2017-07-19T21:27:53.086990z'),
       }),

--- a/src/service/CallApi.js
+++ b/src/service/CallApi.js
@@ -10,51 +10,49 @@ import CallSession from '../domain/CallSession';
 import getApiClient from './getApiClient';
 
 export default class CallApi {
-  static async fetchCallLogs(server: string, session: Session, offset: number, limit: number): Promise<Call[]> {
-    return getApiClient(server).callLogd.listCallLogs(session.token, offset, limit);
+  static async fetchCallLogs(server: string, offset: number, limit: number): Promise<Call[]> {
+    return getApiClient(server).callLogd.listCallLogs(offset, limit);
   }
 
-  static async fetchActiveCalls(server: string, session: Session): Promise<Call[]> {
-    return getApiClient(server).ctidNg.listCalls(session.token);
+  static async fetchActiveCalls(server: string): Promise<Call[]> {
+    return getApiClient(server).ctidNg.listCalls();
   }
 
-  static async fetchCallLogsFromDate(server: string, token: string, from: Date, number: string): Promise<CallLog[]> {
-    return getApiClient(server).callLogd.listCallLogsFromDate(token, from, number);
+  static async fetchCallLogsFromDate(server: string, from: Date, number: string): Promise<CallLog[]> {
+    return getApiClient(server).callLogd.listCallLogsFromDate(from, number);
   }
 
-  static async search(server: string, session: Session, query: string, limit: number): Promise<CallLog[]> {
-    return getApiClient(server).callLogd.search(session.token, query, limit);
+  static async search(server: string, query: string, limit: number): Promise<CallLog[]> {
+    return getApiClient(server).callLogd.search(query, limit);
   }
 
   static async fetchSIP(server: string, session: Session, line: ?Line): Promise<any> {
     const lineToUse = line || session.primaryLine();
-    return getApiClient(server).confd.getUserLineSip(session.token, session.uuid, lineToUse ? lineToUse.id : null);
+    return getApiClient(server).confd.getUserLineSip(session.uuid, lineToUse ? lineToUse.id : null);
   }
 
   static async cancelCall(server: string, session: Session, callSession: CallSession): Promise<void> {
-    return getApiClient(server).ctidNg.cancelCall(session.token, callSession.callId);
+    return getApiClient(server).ctidNg.cancelCall(callSession.callId);
   }
 
   static async makeCall(
     server: string,
-    session: Session,
     callFromLine: Line,
     extension: string,
     isMobile: boolean = false,
   ): Promise<?Call> {
     const lineId = callFromLine ? callFromLine.id : null;
 
-    const response = await getApiClient(server).ctidNg.makeCall(session.token, extension, isMobile, lineId);
+    const response = await getApiClient(server).ctidNg.makeCall(extension, isMobile, lineId);
     return Call.parse(response);
   }
 
   static async relocateCall(
     server: string,
-    session: Session,
     callId: string,
     line: number,
     contactIdentifier?: string,
   ): Promise<Relocation> {
-    return getApiClient(server).ctidNg.relocateCall(session.token, callId, 'line', line, contactIdentifier);
+    return getApiClient(server).ctidNg.relocateCall(callId, 'line', line, contactIdentifier);
   }
 }

--- a/src/service/CallApi.js
+++ b/src/service/CallApi.js
@@ -10,49 +10,39 @@ import CallSession from '../domain/CallSession';
 import getApiClient from './getApiClient';
 
 export default class CallApi {
-  static async fetchCallLogs(server: string, offset: number, limit: number): Promise<Call[]> {
-    return getApiClient(server).callLogd.listCallLogs(offset, limit);
+  static async fetchCallLogs(offset: number, limit: number): Promise<Call[]> {
+    return getApiClient().callLogd.listCallLogs(offset, limit);
   }
 
-  static async fetchActiveCalls(server: string): Promise<Call[]> {
-    return getApiClient(server).ctidNg.listCalls();
+  static async fetchActiveCalls(): Promise<Call[]> {
+    return getApiClient().ctidNg.listCalls();
   }
 
-  static async fetchCallLogsFromDate(server: string, from: Date, number: string): Promise<CallLog[]> {
-    return getApiClient(server).callLogd.listCallLogsFromDate(from, number);
+  static async fetchCallLogsFromDate(from: Date, number: string): Promise<CallLog[]> {
+    return getApiClient().callLogd.listCallLogsFromDate(from, number);
   }
 
-  static async search(server: string, query: string, limit: number): Promise<CallLog[]> {
-    return getApiClient(server).callLogd.search(query, limit);
+  static async search(query: string, limit: number): Promise<CallLog[]> {
+    return getApiClient().callLogd.search(query, limit);
   }
 
-  static async fetchSIP(server: string, session: Session, line: ?Line): Promise<any> {
+  static async fetchSIP(session: Session, line: ?Line): Promise<any> {
     const lineToUse = line || session.primaryLine();
-    return getApiClient(server).confd.getUserLineSip(session.uuid, lineToUse ? lineToUse.id : null);
+    return getApiClient().confd.getUserLineSip(session.uuid, lineToUse ? lineToUse.id : null);
   }
 
-  static async cancelCall(server: string, session: Session, callSession: CallSession): Promise<void> {
-    return getApiClient(server).ctidNg.cancelCall(callSession.callId);
+  static async cancelCall(callSession: CallSession): Promise<void> {
+    return getApiClient().ctidNg.cancelCall(callSession.callId);
   }
 
-  static async makeCall(
-    server: string,
-    callFromLine: Line,
-    extension: string,
-    isMobile: boolean = false,
-  ): Promise<?Call> {
+  static async makeCall(callFromLine: Line, extension: string, isMobile: boolean = false): Promise<?Call> {
     const lineId = callFromLine ? callFromLine.id : null;
 
-    const response = await getApiClient(server).ctidNg.makeCall(extension, isMobile, lineId);
+    const response = await getApiClient().ctidNg.makeCall(extension, isMobile, lineId);
     return Call.parse(response);
   }
 
-  static async relocateCall(
-    server: string,
-    callId: string,
-    line: number,
-    contactIdentifier?: string,
-  ): Promise<Relocation> {
-    return getApiClient(server).ctidNg.relocateCall(callId, 'line', line, contactIdentifier);
+  static async relocateCall(callId: string, line: number, contactIdentifier?: string): Promise<Relocation> {
+    return getApiClient().ctidNg.relocateCall(callId, 'line', line, contactIdentifier);
   }
 }

--- a/src/service/getApiClient.js
+++ b/src/service/getApiClient.js
@@ -3,13 +3,31 @@
 import WazoApiClient from '../api-client';
 
 const clients = {};
+let token = null;
+let refreshToken = null;
+
+export const setToken = (newToken: string) => {
+  token = newToken;
+
+  Object.keys(clients).forEach(server => {
+    clients[server].setToken(token);
+  });
+};
+
+export const setRefreshToken = (newRefreshToken: string) => {
+  refreshToken = newRefreshToken;
+
+  Object.keys(clients).forEach(server => {
+    clients[server].setRefreshToken(refreshToken);
+  });
+};
 
 export default (server: string): WazoApiClient => {
   if (server in clients) {
     return clients[server];
   }
 
-  clients[server] = new WazoApiClient({ server });
+  clients[server] = new WazoApiClient({ server, refreshToken });
 
   return clients[server];
 };

--- a/src/service/getApiClient.js
+++ b/src/service/getApiClient.js
@@ -39,7 +39,7 @@ const fillClient = client => {
   client.setToken(global.token);
   client.setRefreshToken(global.refreshToken);
   client.setClientId(global.clientId);
-  client.onRefreshToken = global.onRefreshToken;
+  client.setOnRefreshToken(global.onRefreshToken);
   client.setRefreshExpiration(global.refreshExpiration);
   client.setRefreshBackend(global.refreshBackend);
 

--- a/src/utils/__tests__/api-requester.test.js
+++ b/src/utils/__tests__/api-requester.test.js
@@ -30,7 +30,7 @@ describe('Calling fetch', () => {
     const body = { a: 1 };
     const url = `https://${server}/api/${path}?a=1`;
 
-    new ApiRequester({ server }).call(path, method, body);
+    new ApiRequester({ server }).call(path, method, body, {});
     expect(global.fetch).toBeCalledWith(url, { method: 'get', body: null, headers: {}, agent: null });
   });
 });

--- a/src/utils/__tests__/api-requester.test.js
+++ b/src/utils/__tests__/api-requester.test.js
@@ -1,5 +1,18 @@
 import ApiRequester from '../api-requester';
 
+const server = 'localhost';
+const path = 'auth';
+const method = 'get';
+const body = { a: 1 };
+const url = `https://${server}/api/${path}?a=1`;
+const token = 'abc';
+const newToken = 'newToken';
+const headers = {
+  Accept: 'application/json',
+  'Content-Type': 'application/json',
+  'X-Auth-Token': token,
+};
+
 describe('Generating query string', () => {
   it('should generate a simple query string from an object', () => {
     expect(ApiRequester.getQueryString({ a: 1, b: 'someString' })).toBe('a=1&b=someString');
@@ -24,13 +37,48 @@ describe('Calling fetch', () => {
     jest.mock('node-fetch/lib/index', () => {});
     global.fetch = jest.fn(() => Promise.resolve({ json: () => Promise.resolve({}) }));
 
-    const server = 'localhost';
-    const path = 'auth';
-    const method = 'get';
-    const body = { a: 1 };
-    const url = `https://${server}/api/${path}?a=1`;
-
     new ApiRequester({ server }).call(path, method, body, {});
     expect(global.fetch).toBeCalledWith(url, { method: 'get', body: null, headers: {}, agent: null });
+  });
+});
+
+describe('With a refresh token', () => {
+  it('should retry the call with a new token', async () => {
+    jest.mock('node-fetch/lib/index', () => {});
+    let calls = 0;
+    global.fetch = jest.fn(() => {
+      calls++;
+      return Promise.resolve({
+        headers: {
+          get: () => 'application/json',
+        },
+        status: calls === 1 ? 401 : 200,
+        json: () => Promise.resolve({}),
+      });
+    });
+
+    const requester = new ApiRequester({ server });
+    requester.token = token;
+
+    requester.refreshTokenCallback = () => {
+      requester.token = newToken;
+      return new Promise(resolve => resolve());
+    };
+
+    const updatedHeaders = {
+      Accept: 'application/json',
+      'Content-Type': 'application/json',
+      'X-Auth-Token': newToken,
+    };
+
+    await requester.call(path, method, body, null);
+
+    expect(global.fetch).toHaveBeenNthCalledWith(1, url, { method: 'get', body: null, headers, agent: null });
+    expect(global.fetch).toHaveBeenNthCalledWith(2, url, {
+      method: 'get',
+      body: null,
+      headers: updatedHeaders,
+      agent: null,
+    });
   });
 });

--- a/src/utils/api-requester.js
+++ b/src/utils/api-requester.js
@@ -123,9 +123,9 @@ export default class ApiRequester {
 
         return promise.then(async err => {
           // Check if the token is incorrect
-          if (firstCall && response.status === 401 && err.details && err.details.invalid_token) {
-            this.token = await this.refreshTokenCallback();
-            return this.call(path, method, body, headers, parse, false);
+          if (firstCall && response.status === 401) {
+            // Replay the call after refreshing the token
+            return this.refreshTokenCallback().then(() => this.call(path, method, body, headers, parse, false));
           }
 
           throw typeof err === 'string'

--- a/src/web-rtc-client.js
+++ b/src/web-rtc-client.js
@@ -653,8 +653,10 @@ export default class WebRTCClient extends Emitter {
     }
 
     const client = new ApiClient({ server: config.host });
+    client.setToken(session.token);
+    client.setRefreshToken(session.refreshToken);
 
-    return client.confd.getUserLineSipFromToken(session.token, session.uuid).then(sipLine => ({
+    return client.confd.getUserLineSipFromToken(session.uuid).then(sipLine => ({
       authorizationUser: sipLine.username,
       password: sipLine.secret,
       uri: `${sipLine.username}@${config.host}`,

--- a/src/websocket-client.js
+++ b/src/websocket-client.js
@@ -1,4 +1,5 @@
 // @flow
+/* eslint-disable no-underscore-dangle */
 import ReconnectingWebSocket from 'reconnecting-websocket';
 import Emitter from './utils/Emitter';
 import type { WebSocketMessage } from './types/WebSocketMessage';
@@ -45,7 +46,7 @@ class WebSocketClient extends Emitter {
   }
 
   connect() {
-    this.socket = new ReconnectingWebSocket(`wss://${this.host}/api/websocketd/?token=${this.token}`, [], this.options);
+    this.socket = new ReconnectingWebSocket(this._getUrl(), [], this.options);
     if (this.options.binaryType) {
       this.socket.binaryType = this.options.binaryType;
     }
@@ -113,6 +114,19 @@ class WebSocketClient extends Emitter {
       default:
         this.eventEmitter.emit('message', message);
     }
+  }
+
+  updateToken(token: string) {
+    this.token = token;
+
+    if (this.socket) {
+      // $FlowFixMe
+      this.socket._url = this._getUrl();
+    }
+  }
+
+  _getUrl() {
+    return `wss://${this.host}/api/websocketd/?token=${this.token}`;
   }
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -4452,10 +4452,10 @@ flatted@^2.0.0:
   resolved "https://registry.yarnpkg.com/flatted/-/flatted-2.0.1.tgz#69e57caa8f0eacbc281d2e2cb458d46fdb449e08"
   integrity sha512-a1hQMktqW9Nmqr5aktAux3JMNqaucxGcjtjWnZLHX7yyPCmlSV3M54nGYbqT8K+0GhF3NBgmJCc3ma+WOgX8Jg==
 
-flow-bin@^0.102.0:
-  version "0.102.0"
-  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.102.0.tgz#3d5de44bcc26d26585e932b3201988b766f9b380"
-  integrity sha512-mYon6noeLO0Q5SbiWULLQeM1L96iuXnRtYMd47j3bEWXAwUW9EnwNWcn+cZg/jC/Dg4Wj/jnkdTDEuFtbeu1ww==
+flow-bin@^0.108.0:
+  version "0.108.0"
+  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.108.0.tgz#6a42c85fd664d23dd937d925851e8e6ab5d71393"
+  integrity sha512-hPEyCP1J8rdhNDfCAA5w7bN6HUNBDcHVg/ABU5JVo0gUFMx+uRewpyEH8LlLBGjVQuIpbaPpaqpoaQhAVyaYww==
 
 flow-remove-types@^1.0.0, flow-remove-types@^1.1.0:
   version "1.2.3"


### PR DESCRIPTION
⚠️ Breaking change: API methods don't take a token as first parameter anymore.

```js
const client = new WazoApiClient({ server: ..., clientId: 'myClientId' });

const { refreshToken, token, uuid } = await client.auth.logIn({ username: '...', password: '...', expiration: 3 });
client.setToken(token);
client.setRefreshToken(refreshToken);

await new Promise(resolve => setTimeout(resolve, 5000));

const senderId = await client.auth.getPushNotificationSenderId(uuid);
console.log('senderId', senderId);
```

- [x] add tests