### PR TITLE
[WDA-1202] Fix play sound on call termination

### DIFF
--- a/src/domain/Phone/WebRTCPhone.js
+++ b/src/domain/Phone/WebRTCPhone.js
@@ -594,10 +594,7 @@ export default class WebRTCPhone extends Emitter implements Phone {
 
     if (!this.currentSipSession && this.incomingSessions.length > 0) {
       this.eventEmitter.emit('playRingingSound', this.audioOutputDeviceId);
-      return;
     }
-
-    this.eventEmitter.emit('playHangupSound', this.audioOutputDeviceId);
   }
 
   onConnectionMade(): void {}


### PR DESCRIPTION
No need to play hangup sound in `phone.endCurrentCall` as `phone.  _onCallTerminated` already covers it -- and more