### PR TITLE
zuul: fix installation of yarn

### DIFF
--- a/zuul.d/pre.yaml
+++ b/zuul.d/pre.yaml
@@ -3,6 +3,7 @@
   tasks:
     - name: install yarn
       become: yes
-      package:
+      apt:
         name: yarnpkg
         state: present
+        update_cache: yes

--- a/zuul.yaml
+++ b/zuul.yaml
@@ -13,3 +13,7 @@
       jobs:
         - wazo-js-sdk-yarn-test:
             nodeset: debian10-vm
+    auto-merge:
+      jobs:
+        - wazo-js-sdk-yarn-test:
+            nodeset: debian10-vm


### PR DESCRIPTION
Why:

* When Debian updates their repo, we need to fetch the latest version of
packages
* Else, we may get an error like

E: Failed to fetch
http://deb.debian.org/debian/pool/main/n/nodejs/libnode64_10.19.0~dfsg1-1_amd64.deb
404  Not Found [IP: 199.232.36.204 80]