### PR TITLE
Prevent a null CallSession callId

### DIFF
--- a/src/domain/Phone/WebRTCPhone.js
+++ b/src/domain/Phone/WebRTCPhone.js
@@ -676,7 +676,7 @@ export default class WebRTCPhone extends Emitter implements Phone {
       await this.client.register();
     }
     if (this.currentSipSession) {
-      this.holdSipSession(this.currentSipSession, null, true);
+      this.holdSipSession(this.currentSipSession, undefined, true);
     }
 
     let sipSession: Session;


### PR DESCRIPTION
For some reason, that `null` generates a `CallSession.callId = null`, which was ultimately throwing a monkey wrench into the switchboard's indirect transfer process. 