### PR TITLE
[WDA-1403] Fix hangup on audio-answered video calls

### DIFF
--- a/src/web-rtc-client.js
+++ b/src/web-rtc-client.js
@@ -1139,7 +1139,9 @@ export default class WebRTCClient extends Emitter {
   _cleanupMedia(session: Session) {
     const sessionId = this.getSipSessionId(session);
     if (session && sessionId in this.videoSessions) {
-      this.videoSessions[this.getSipSessionId(session)].local.getTracks().forEach(track => track.stop());
+      if (this.videoSessions[this.getSipSessionId(session)].local) {
+        this.videoSessions[this.getSipSessionId(session)].local.getTracks().forEach(track => track.stop());
+      }
       delete this.videoSessions[this.getSipSessionId(session)];
     }
 


### PR DESCRIPTION
Takes care of this corner case:
- Bob video-calls Alice
- Alice answers in audio
- Alice holds Bob, and comes back
- Alice hangs up; fails -- gotta hangup again from the banner 