### PR TITLE
Fix missing iceRestart when losing connection

### DIFF
--- a/src/domain/Phone/WebRTCPhone.js
+++ b/src/domain/Phone/WebRTCPhone.js
@@ -192,7 +192,7 @@ export default class WebRTCPhone extends Emitter implements Phone {
   }
 
   async sendReinvite(callSession: ?CallSession, constraints: ?Object = null, conference: boolean = false,
-    audioOnly: boolean = false) {
+    audioOnly: boolean = false, iceRestart: boolean = false) {
     const sipSession = this.findSipSession(callSession);
     logger.info('WebRTC phone - send reinvite', {
       sessionId: sipSession ? sipSession.id : null,
@@ -223,7 +223,7 @@ export default class WebRTCPhone extends Emitter implements Phone {
       }
     }
 
-    return this.client.reinvite(sipSession, constraints, conference, audioOnly);
+    return this.client.reinvite(sipSession, constraints, conference, audioOnly, iceRestart);
   }
 
   getUserAgent() {
@@ -1429,7 +1429,8 @@ export default class WebRTCPhone extends Emitter implements Phone {
         && this.currentSipSession.state === SessionState.Established) {
         this.shouldSendReinvite = false;
         try {
-          this.sendReinvite(this.currentCallSession);
+          // Send reinvite with iceRestart
+          this.sendReinvite(this.currentCallSession, null, false, false, true);
         } catch (e) {
           logger.error('WebRTC reinvite after register, error', { message: e.message, stack: e.stack });
         }

--- a/src/web-rtc-client.js
+++ b/src/web-rtc-client.js
@@ -1115,7 +1115,7 @@ export default class WebRTCClient extends Emitter {
   }
 
   reinvite(sipSession: Session, newConstraints: ?Object = null, conference: boolean = false,
-    audioOnly: boolean = false) {
+    audioOnly: boolean = false, iceRestart: boolean = false) {
     if (!sipSession) {
       return false;
     }
@@ -1197,7 +1197,7 @@ export default class WebRTCClient extends Emitter {
         conference,
         audioOnly,
         offerOptions: {
-          iceRestart: false,
+          iceRestart,
         },
       },
     });


### PR DESCRIPTION
We have to renegociate ice after losing the connection.
Was OK in 0.36.x but not since the big refactoring in 0.37.x