### PR TITLE
[WAZO-2697] Add simple api login ldap support

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,7 +224,7 @@ Wazo.Auth.fetchOptions({
   - Options passed to all the `fetch` requests of the SDK.
 
 ### Authenticating an user
-```
+```js
 const session = await Wazo.Auth.logIn(username, password);
 ```
 
@@ -233,7 +233,12 @@ const session = await Wazo.Auth.logIn(username, password);
 
 - `password`: string
   - User's password
- 
+
+- `backend`: string
+  - Optional string. If omitted, defaults to wazo_user
+
+- `tenantId`: string
+  - Optional string. The tenant identifier (uuid or slug). Needed when backend is external (not wazo_user)
 Returns as `Wazo.domain.Session`. This object contains, among other information, the user's token.
 
 Note: you need to set `clientId` in your WazoAPIClient in order to get a refresh token in the returned `Session`.

--- a/src/api/auth.js
+++ b/src/api/auth.js
@@ -16,7 +16,8 @@ import type {
 } from '../domain/types';
 import Session from '../domain/Session';
 
-const DEFAULT_BACKEND_USER = 'wazo_user';
+export const DEFAULT_BACKEND_USER = 'wazo_user';
+export const BACKEND_LDAP_USER = 'ldap_user';
 export const DETAULT_EXPIRATION = 3600;
 
 export default (client: ApiRequester, baseUrl: string) => ({

--- a/src/simple/index.js
+++ b/src/simple/index.js
@@ -1,5 +1,5 @@
 /* global window */
-import Auth, { InvalidSubscription, InvalidAuthorization } from './Auth';
+import Auth, { InvalidSubscription, InvalidAuthorization, NoTenantIdError } from './Auth';
 import Phone from './Phone';
 import Websocket from './Websocket';
 import Room from './room/Room';
@@ -103,6 +103,7 @@ const Wazo = {
   InvalidAuthorization,
   CanceledCallError,
   SFUNotAvailableError,
+  NoTenantIdError,
 };
 
 if (window) {


### PR DESCRIPTION
## Summary of the changes
- `backend` and `tenantId` can now be provided when using the simple API to log in
- introduces backend constants in Auth class