### PR TITLE
Remove stack.dev.wazo.io references

### DIFF
--- a/README.md
+++ b/README.md
@@ -928,7 +928,7 @@ import { WazoWebSocketClient } from '@wazo/sdk';
 
 ```js
 const client = new WazoApiClient({
-  server: 'stack.dev.wazo.io', // required string
+  server: 'stack.example.com', // required string
   agent: null, // http(s).Agent instance, allows custom proxy, unsecured https, certificate etc.
   clientId: null, // Set an identifier for your app when using refreshToken
   isMobile: false,
@@ -1196,7 +1196,7 @@ Use this generic method to request endpoints directly.
 
 ```js
 const requester = new ApiRequester({ 
-  server: 'stack.dev.wazo.io', // Engine server
+  server: 'stack.example.com', // Engine server
   refreshTokenCallback: () => {}, // Called when the token is refreshed
   clientId: 'my-id', // ClientId used for refreshToken
   agent: null, // http(s).Agent instance, allows custom proxy, unsecured https, certificate etc.
@@ -1218,7 +1218,7 @@ const session = await client.auth.logIn({ ... }); // log in
 
 const client = new WazoWebRTCClient({
   displayName: 'From WEB',
-  host: 'stack.dev.wazo.io',
+  host: 'stack.example.com',
   websocketSip: 'other.url.com', // Allows to connect throught another URL than host (default to `host` is not set).
   media: {
     audio: boolean,

--- a/src/domain/__tests__/Line.test.js
+++ b/src/domain/__tests__/Line.test.js
@@ -11,7 +11,7 @@ describe('Line domain', () => {
         username: 'ipcor1pj',
         links: [
           {
-            href: 'https://stack.dev.wazo.io/api/confd/1.1/endpoints/sip/19',
+            href: 'https://stack.example.com/api/confd/1.1/endpoints/sip/19',
             rel: 'endpoint_sip',
           },
         ],
@@ -25,7 +25,7 @@ describe('Line domain', () => {
           context: 'default',
           links: [
             {
-              href: 'https://stack.dev.wazo.io/api/confd/1.1/extensions/59',
+              href: 'https://stack.example.com/api/confd/1.1/extensions/59',
               rel: 'extensions',
             },
           ],
@@ -33,7 +33,7 @@ describe('Line domain', () => {
       ],
       links: [
         {
-          href: 'https://stack.dev.wazo.io/api/confd/1.1/lines/8',
+          href: 'https://stack.example.com/api/confd/1.1/lines/8',
           rel: 'lines',
         },
       ],
@@ -51,7 +51,7 @@ describe('Line domain', () => {
             context: 'default',
             links: [
               {
-                href: 'https://stack.dev.wazo.io/api/confd/1.1/extensions/59',
+                href: 'https://stack.example.com/api/confd/1.1/extensions/59',
                 rel: 'extensions',
               },
             ],
@@ -61,7 +61,7 @@ describe('Line domain', () => {
           id: 19,
           links: [
             {
-              href: 'https://stack.dev.wazo.io/api/confd/1.1/endpoints/sip/19',
+              href: 'https://stack.example.com/api/confd/1.1/endpoints/sip/19',
               rel: 'endpoint_sip',
             },
           ],

--- a/src/simple/Softphone.js
+++ b/src/simple/Softphone.js
@@ -120,8 +120,7 @@ class Softphone {
     window.addEventListener('message', this._onMessage.bind(this), false);
 
     if (!server) {
-      // eslint-disable-next-line no-param-reassign
-      server = 'stack.dev.wazo.io';
+      throw new Error('`server` is not set');
     }
 
     const config: Object = { server };


### PR DESCRIPTION
Heads up: throwing an error in `simple/Softphone.js` as opposed to defaulting to `stack.dev` -- not sure this is the appropriate way to handle this.