### PR TITLE
[WDA-1981] add force param for WebRTC changeAudioInputDevice

### DIFF
--- a/README.md
+++ b/README.md
@@ -1636,7 +1636,7 @@ phone.changeRingDevice(someDevice: string);
 ##### Updating audio input device
 
 ```js
-phone.changeAudioInputDevice(someDevice: string);
+phone.changeAudioInputDevice(someDevice: string, session: ?Inviter, force: ?boolean);
 ```
 
 ##### Updating video input device

--- a/src/__tests__/web-rtc-client.test.js
+++ b/src/__tests__/web-rtc-client.test.js
@@ -43,3 +43,53 @@ describe('WebRTC client', () => {
     expect(client.isAudioMuted(oldKindUnmuted)).toBeFalsy();
   });
 });
+
+describe('changeAudioInputDevice', () => {
+  const defaultId = 'default';
+  const deviceId = 'device1';
+  const constraints = { audio: { deviceId: { exact: defaultId } }, video: null };
+
+  const session = {
+    sessionDescriptionHandler: {
+      peerConnection: {
+        getSenders: () => [{ track: { kind: 'audio', enabled: true } }],
+      },
+    },
+  };
+
+  const stream = {};
+  const getAudioTracksMock = jest.fn(() => []);
+  Object.defineProperty(stream, 'getAudioTracks', {
+    value: getAudioTracksMock,
+  });
+
+  const getUserMediaMock = jest.fn(async () => {
+    return new Promise(resolve => {
+      resolve(stream);
+    });
+  });
+
+  Object.defineProperty(global.navigator, 'mediaDevices', {
+    value: {
+      getUserMedia: getUserMediaMock,
+    },
+  });
+
+  it('should change the audio input track if the provided id is different', async () => {
+    client.setMediaConstraints(constraints);
+    expect(client.getAudioDeviceId()).toBe(defaultId);
+    expect(client.changeAudioInputDevice(deviceId, session)).toBeTruthy();
+  });
+
+  it('should NOT change the audio input track if the provided id is the same', async () => {
+    client.setMediaConstraints(constraints);
+    expect(client.getAudioDeviceId()).toBe(defaultId);
+    expect(client.changeAudioInputDevice(defaultId, session)).toBeFalsy();
+  });
+
+  it('should change the audio input track if the provided id is the same and force param is TRUE', async () => {
+    client.setMediaConstraints(constraints);
+    expect(client.getAudioDeviceId()).toBe(defaultId);
+    expect(client.changeAudioInputDevice(defaultId, session, true)).toBeTruthy();
+  });
+});

--- a/src/domain/Phone/WebRTCPhone.js
+++ b/src/domain/Phone/WebRTCPhone.js
@@ -668,10 +668,10 @@ export default class WebRTCPhone extends Emitter implements Phone {
     this.audioRingVolume = volume;
   }
 
-  changeAudioInputDevice(id: string) {
+  changeAudioInputDevice(id: string, force: ?boolean) {
     logger.info('WebRTC phone - changeAudio input device', { deviceId: id });
 
-    return this.client.changeAudioInputDevice(id, this.currentSipSession);
+    return this.client.changeAudioInputDevice(id, this.currentSipSession, force);
   }
 
   changeVideoInputDevice(id: ?string) {

--- a/src/web-rtc-client.js
+++ b/src/web-rtc-client.js
@@ -1070,11 +1070,11 @@ export default class WebRTCClient extends Emitter {
     });
   }
 
-  changeAudioInputDevice(id: string, session: ?Inviter) {
+  changeAudioInputDevice(id: string, session: ?Inviter, force: ?boolean) {
     const currentId = this.getAudioDeviceId();
     logger.info('setting audio input device', { id, currentId, session: !!session });
 
-    if (id === currentId) {
+    if (!force && id === currentId) {
       return null;
     }
 


### PR DESCRIPTION
**Summary of changes**
- Adds a `force` param to change the audio input device in cases where the device has changed but has the same `id` than before (e.g user unplugs a microphone with id `default` and OS fallbacks to a new default microphone and is given id `default`).