### PR TITLE
[WDA-1981] Handle default device to new default device track change

### DIFF
--- a/src/__tests__/web-rtc-client.test.js
+++ b/src/__tests__/web-rtc-client.test.js
@@ -69,27 +69,41 @@ describe('changeAudioInputDevice', () => {
     });
   });
 
+  const devices = [
+    { deviceId: 'default', kind: 'audioinput', label: 'Default - Fake Microphone', groupId: 'fak3Gr0up3' },
+    { deviceId: 'fak3d3v1c3', kind: 'audioinput', label: 'Fake Microphone', groupId: 'fak3Gr0up3' },
+  ];
+  const enumerateDevicesMock = jest.fn(async () => {
+    return new Promise(resolve => {
+      resolve(devices);
+    });
+  });
+
   Object.defineProperty(global.navigator, 'mediaDevices', {
     value: {
       getUserMedia: getUserMediaMock,
+      enumerateDevices: enumerateDevicesMock,
     },
   });
 
   it('should change the audio input track if the provided id is different', async () => {
     client.setMediaConstraints(constraints);
     expect(client.getAudioDeviceId()).toBe(defaultId);
-    expect(client.changeAudioInputDevice(deviceId, session)).toBeTruthy();
+    const result = await client.changeAudioInputDevice(deviceId, session);
+    expect(result).toBeTruthy();
   });
 
   it('should NOT change the audio input track if the provided id is the same', async () => {
     client.setMediaConstraints(constraints);
     expect(client.getAudioDeviceId()).toBe(defaultId);
-    expect(client.changeAudioInputDevice(defaultId, session)).toBeFalsy();
+    const result = await client.changeAudioInputDevice(defaultId, session);
+    expect(result).toBeFalsy();
   });
 
   it('should change the audio input track if the provided id is the same and force param is TRUE', async () => {
     client.setMediaConstraints(constraints);
     expect(client.getAudioDeviceId()).toBe(defaultId);
-    expect(client.changeAudioInputDevice(defaultId, session, true)).toBeTruthy();
+    const result = await client.changeAudioInputDevice(defaultId, session, true);
+    expect(result).toBeTruthy();
   });
 });

--- a/src/web-rtc-client.js
+++ b/src/web-rtc-client.js
@@ -1089,6 +1089,9 @@ export default class WebRTCClient extends Emitter {
         const targetDevice = devices.find(device => device.label === deviceLabel);
         if (targetDevice) {
           deviceId = targetDevice.deviceId;
+          if (!force && deviceId === currentId) {
+            return null;
+          }
         }
       }
     }

--- a/src/web-rtc-client.js
+++ b/src/web-rtc-client.js
@@ -1070,7 +1070,7 @@ export default class WebRTCClient extends Emitter {
     });
   }
 
-  changeAudioInputDevice(id: string, session: ?Inviter, force: ?boolean) {
+  async changeAudioInputDevice(id: string, session: ?Inviter, force: ?boolean) {
     const currentId = this.getAudioDeviceId();
     logger.info('setting audio input device', { id, currentId, session: !!session });
 
@@ -1078,33 +1078,47 @@ export default class WebRTCClient extends Emitter {
       return null;
     }
 
+    // in order to handle an audio track change for default devices
+    // we need the actual id of the device (not 'default')
+    let deviceId = id;
+    if (id === 'default' && navigator.mediaDevices) {
+      const devices = await navigator.mediaDevices.enumerateDevices();
+      const defaultDevice = devices.find(device => device.deviceId === 'default');
+      if (defaultDevice) {
+        const deviceLabel = defaultDevice.label.replace('Default - ', '');
+        const targetDevice = devices.find(device => device.label === deviceLabel);
+        if (targetDevice) {
+          deviceId = targetDevice.deviceId;
+        }
+      }
+    }
+
     // let's update the local audio value
     if (this.audio) {
       this.audio = {
         deviceId: {
-          exact: id,
+          exact: deviceId,
         },
       };
     }
 
-    if (session) {
+    if (session && navigator.mediaDevices) {
       const sdh = session.sessionDescriptionHandler;
       const pc = sdh.peerConnection;
 
-      // $FlowFixMe
-      return navigator.mediaDevices.getUserMedia({ audio: { deviceId: { exact: id } } }).then(async stream => {
-        const audioTrack = stream.getAudioTracks()[0];
-        const sender = pc && pc.getSenders().find(s => audioTrack && s && s.track && s.track.kind === audioTrack.kind);
+      const constraints = { audio: { deviceId: { exact: deviceId } } };
+      const stream = await navigator.mediaDevices.getUserMedia(constraints);
+      const audioTrack = stream.getAudioTracks()[0];
+      const sender = pc && pc.getSenders().find(s => audioTrack && s && s.track && s.track.kind === audioTrack.kind);
 
-        if (sender) {
-          if (sender.track) {
-            audioTrack.enabled = sender.track.enabled;
-          }
-          sender.replaceTrack(audioTrack);
+      if (sender) {
+        if (sender.track) {
+          audioTrack.enabled = sender.track.enabled;
         }
+        sender.replaceTrack(audioTrack);
+      }
 
-        return stream;
-      });
+      return stream;
     }
   }
 


### PR DESCRIPTION
**Summary of changes**
- to perform a track change, the actual `deviceId` of the default device is used. If it cannot be found, `default` will be used.
- fix flow