### PR TITLE
Await for hangup actions to let the try/catch block do its job

### DIFF
--- a/src/web-rtc-client.ts
+++ b/src/web-rtc-client.ts
@@ -674,7 +674,7 @@ export default class WebRTCClient extends Emitter {
     });
   }
 
-  hangup(session: Invitation | Inviter): Promise<OutgoingByeRequest | null> {
+  async hangup(session: Invitation | Inviter): Promise<OutgoingByeRequest | null> {
     const {
       state,
       id,
@@ -708,10 +708,10 @@ export default class WebRTCClient extends Emitter {
 
       // Handle different session status
       if (actions[state]) {
-        return actions[state]();
+        return await actions[state]();
       }
 
-      return bye();
+      return await bye();
     } catch (error: any) {
       logger.warn('sdk webrtc hangup, error', error);
     }


### PR DESCRIPTION
`reject`, `cancel` and `bye` are async. So we need to await them to be able to fall in the catch block.