### PR TITLE
tweak timeout options for the websocket

### DIFF
--- a/src/simple/Websocket.ts
+++ b/src/simple/Websocket.ts
@@ -69,6 +69,10 @@ class Websocket extends Emitter implements IWebsocket {
     }, {
       rejectUnauthorized: false,
       binaryType: 'arraybuffer',
+      timeoutInterval: 10000,
+      reconnectInterval: 4000 + Math.random() * 2000, // 4 to 6 seconds
+      maxReconnectInterval: 50000 + Math.random() * 20000, // 50 to 70 seconds
+      reconnectDecay: 1.5 + Math.random(), // 1.5 to 2.5 times the last reconnectInterval
     });
     this.ws.connect();
     // Re-emit all events


### PR DESCRIPTION
this change makes the timeout 10 seconds instead of 2 seconds. It also adds some randomization on the reconnection delay to avoid synchronized clients reconnecting all at once