### PR TITLE
[WDA-1972] Introduce limit param for dird contact search

### DIFF
--- a/README.md
+++ b/README.md
@@ -833,7 +833,7 @@ client.confd.listApplications();
 
 Use Dird to interact with directories.
 ```js
-client.dird.search(context: string, term: string, limit: number);
+client.dird.search(context: string, term: string, offset: number, limit: number);
 client.dird.listPersonalContacts();
 client.dird.addContact(newContact: NewContact);
 client.dird.editContact(contact: Contact);

--- a/README.md
+++ b/README.md
@@ -833,14 +833,14 @@ client.confd.listApplications();
 
 Use Dird to interact with directories.
 ```js
-client.dird.search(context, term);
+client.dird.search(context: string, term: string, limit: number);
 client.dird.listPersonalContacts();
-client.dird.addContact(newContact);
-client.dird.editContact(contact);
-client.dird.deleteContact(contactUuid);
-client.dird.listFavorites(context);
-client.dird.markAsFavorite(source, sourceId);
-client.dird.removeFavorite(source, sourceId);
+client.dird.addContact(newContact: NewContact);
+client.dird.editContact(contact: Contact);
+client.dird.deleteContact(contactUuid: UUID);
+client.dird.listFavorites(context: string);
+client.dird.markAsFavorite(source: string, sourceId: string);
+client.dird.removeFavorite(source: string, sourceId: string);
 ```
 
 #### Agentd

--- a/src/api/dird.ts
+++ b/src/api/dird.ts
@@ -52,9 +52,9 @@ type ContactSearchQueryParams = {
   uuid?: string;
 } | null;
 export default ((client: ApiRequester, baseUrl: string): DirD => ({
-  search: (context: string, term: string, limit: (number | null) = null): Promise<Array<Contact>> => client.get(`${baseUrl}/directories/lookup/${context}`, {
+  search: (context: string, term: string, offset = 0, limit: (number | null) = null): Promise<Array<Contact>> => client.get(`${baseUrl}/directories/lookup/${context}`, {
     term,
-  }).then((response: ContactsResponse) => Contact.parseMany(response, limit)),
+  }).then((response: ContactsResponse) => Contact.parseMany(response, offset, limit)),
   listPersonalContacts: (queryParams: ContactSearchQueryParams = null): Promise<Array<Contact>> => client.get(`${baseUrl}/personal`, queryParams).then((response: any) => Contact.parseManyPersonal(response.items)),
   fetchPersonalContact: (contactUuid: string): Promise<Contact> => client.get(`${baseUrl}/personal/${contactUuid}`).then(Contact.parsePersonal),
   addContact: (contact: NewContact): Promise<Contact> => client.post(`${baseUrl}/personal`, getContactPayload(contact)).then(Contact.parsePersonal),

--- a/src/api/dird.ts
+++ b/src/api/dird.ts
@@ -5,6 +5,7 @@ import Contact from '../domain/Contact';
 import type { NewContact } from '../domain/Contact';
 import type { DirectorySource, DirectorySources } from '../domain/DirectorySource';
 import type { Sources } from '../index';
+import { ContactsResponse } from '../index';
 
 const getContactPayload = (contact: NewContact | Contact) => ({
   email: contact.email,
@@ -51,9 +52,9 @@ type ContactSearchQueryParams = {
   uuid?: string;
 } | null;
 export default ((client: ApiRequester, baseUrl: string): DirD => ({
-  search: (context: string, term: string): Promise<Array<Contact>> => client.get(`${baseUrl}/directories/lookup/${context}`, {
+  search: (context: string, term: string, limit = -1): Promise<Array<Contact>> => client.get(`${baseUrl}/directories/lookup/${context}`, {
     term,
-  }).then(Contact.parseMany),
+  }).then((response: ContactsResponse) => Contact.parseMany(response, limit)),
   listPersonalContacts: (queryParams: ContactSearchQueryParams = null): Promise<Array<Contact>> => client.get(`${baseUrl}/personal`, queryParams).then((response: any) => Contact.parseManyPersonal(response.items)),
   fetchPersonalContact: (contactUuid: string): Promise<Contact> => client.get(`${baseUrl}/personal/${contactUuid}`).then(Contact.parsePersonal),
   addContact: (contact: NewContact): Promise<Contact> => client.post(`${baseUrl}/personal`, getContactPayload(contact)).then(Contact.parsePersonal),

--- a/src/api/dird.ts
+++ b/src/api/dird.ts
@@ -52,7 +52,7 @@ type ContactSearchQueryParams = {
   uuid?: string;
 } | null;
 export default ((client: ApiRequester, baseUrl: string): DirD => ({
-  search: (context: string, term: string, limit = -1): Promise<Array<Contact>> => client.get(`${baseUrl}/directories/lookup/${context}`, {
+  search: (context: string, term: string, limit: (number | null) = null): Promise<Array<Contact>> => client.get(`${baseUrl}/directories/lookup/${context}`, {
     term,
   }).then((response: ContactsResponse) => Contact.parseMany(response, limit)),
   listPersonalContacts: (queryParams: ContactSearchQueryParams = null): Promise<Array<Contact>> => client.get(`${baseUrl}/personal`, queryParams).then((response: any) => Contact.parseManyPersonal(response.items)),

--- a/src/domain/Contact.ts
+++ b/src/domain/Contact.ts
@@ -326,12 +326,13 @@ export default class Contact {
     return aLastName.localeCompare(bLastName);
   }
 
-  static parseMany(response: ContactsResponse): Array<Contact> {
-    if (!response || !response.results) {
+  static parseMany(response: ContactsResponse, limit = -1): Array<Contact> {
+    if (!response || !response.results || limit === 0) {
       return [];
     }
 
-    return response.results.map(r => Contact.parse(r, response.column_types));
+    const results = limit > 0 ? response.results.slice(0, limit) : response.results;
+    return results.map(r => Contact.parse(r, response.column_types));
   }
 
   static manyGraphQlWithNumbersParser(numbers: string[]): (...args: Array<any>) => any {

--- a/src/domain/Contact.ts
+++ b/src/domain/Contact.ts
@@ -331,7 +331,7 @@ export default class Contact {
       return [];
     }
 
-    const results = limit !== null && limit > 0 ? response.results.slice(offset, limit) : response.results.slice(offset);
+    const results = limit !== null && limit > 0 ? response.results.slice(offset, limit) : offset > 0 ? response.results.slice(offset) : response.results;
     return results.map(r => Contact.parse(r, response.column_types));
   }
 

--- a/src/domain/Contact.ts
+++ b/src/domain/Contact.ts
@@ -326,12 +326,12 @@ export default class Contact {
     return aLastName.localeCompare(bLastName);
   }
 
-  static parseMany(response: ContactsResponse, limit: (number | null) = null): Array<Contact> {
+  static parseMany(response: ContactsResponse, offset = 0, limit: (number | null) = null): Array<Contact> {
     if (!response || !response.results || limit === 0) {
       return [];
     }
 
-    const results = limit !== null && limit > 0 ? response.results.slice(0, limit) : response.results;
+    const results = limit !== null && limit > 0 ? response.results.slice(offset, limit) : response.results.slice(offset);
     return results.map(r => Contact.parse(r, response.column_types));
   }
 

--- a/src/domain/Contact.ts
+++ b/src/domain/Contact.ts
@@ -326,12 +326,12 @@ export default class Contact {
     return aLastName.localeCompare(bLastName);
   }
 
-  static parseMany(response: ContactsResponse, limit = -1): Array<Contact> {
+  static parseMany(response: ContactsResponse, limit: (number | null) = null): Array<Contact> {
     if (!response || !response.results || limit === 0) {
       return [];
     }
 
-    const results = limit > 0 ? response.results.slice(0, limit) : response.results;
+    const results = limit !== null && limit > 0 ? response.results.slice(0, limit) : response.results;
     return results.map(r => Contact.parse(r, response.column_types));
   }
 

--- a/src/domain/__tests__/Contact.test.ts
+++ b/src/domain/__tests__/Contact.test.ts
@@ -376,4 +376,13 @@ describe('Contact domain', () => {
     const contacts = Contact.parseMany(response, -1);
     expect(contacts).toEqual([parsedContact1, parsedContact2]);
   });
+  it('returns all contacts when parsing many contacts with a null limit', () => {
+    const response = {
+      ...genericContactResponse,
+      results: [contact1, contact2],
+    };
+
+    const contacts = Contact.parseMany(response, null);
+    expect(contacts).toEqual([parsedContact1, parsedContact2]);
+  });
 });

--- a/src/domain/__tests__/Contact.test.ts
+++ b/src/domain/__tests__/Contact.test.ts
@@ -337,7 +337,7 @@ describe('Contact domain', () => {
       results: [contact1, contact2],
     };
 
-    const contacts = Contact.parseMany(response, 1000);
+    const contacts = Contact.parseMany(response, 0, 1000);
     expect(contacts).toEqual([parsedContact1, parsedContact2]);
   });
   it('returns limited contacts when parsing many contacts with a smaller limit than number of results', () => {
@@ -346,7 +346,7 @@ describe('Contact domain', () => {
       results: [contact1],
     };
 
-    const contacts = Contact.parseMany(response, 1);
+    const contacts = Contact.parseMany(response, 0, 1);
     expect(contacts).toEqual([parsedContact1]);
   });
   it('returns all contacts when parsing many contacts with same limit than number of results', () => {
@@ -355,7 +355,7 @@ describe('Contact domain', () => {
       results: [contact1, contact2],
     };
 
-    const contacts = Contact.parseMany(response, 2);
+    const contacts = Contact.parseMany(response, 0, 2);
     expect(contacts).toEqual([parsedContact1, parsedContact2]);
   });
   it('returns an empty array when parsing many contact with limit of 0', () => {
@@ -364,7 +364,7 @@ describe('Contact domain', () => {
       results: [contact1, contact2],
     };
 
-    const contacts = Contact.parseMany(response, 0);
+    const contacts = Contact.parseMany(response, 0, 0);
     expect(contacts).toEqual([]);
   });
   it('returns all contacts when parsing many contacts with a negative limit', () => {
@@ -373,7 +373,7 @@ describe('Contact domain', () => {
       results: [contact1, contact2],
     };
 
-    const contacts = Contact.parseMany(response, -1);
+    const contacts = Contact.parseMany(response, 0, -1);
     expect(contacts).toEqual([parsedContact1, parsedContact2]);
   });
   it('returns all contacts when parsing many contacts with a null limit', () => {
@@ -382,7 +382,16 @@ describe('Contact domain', () => {
       results: [contact1, contact2],
     };
 
-    const contacts = Contact.parseMany(response, null);
+    const contacts = Contact.parseMany(response, 0, null);
     expect(contacts).toEqual([parsedContact1, parsedContact2]);
+  });
+  it('returns all contacts after the first one when parsing many contacts with an offset of 1', () => {
+    const response = {
+      ...genericContactResponse,
+      results: [contact1, contact2],
+    };
+
+    const contacts = Contact.parseMany(response, 1, null);
+    expect(contacts).toEqual([parsedContact2]);
   });
 });

--- a/src/domain/__tests__/Contact.test.ts
+++ b/src/domain/__tests__/Contact.test.ts
@@ -1,5 +1,138 @@
 import Contact from '../Contact';
 
+const genericContactResponse = {
+  column_types: [
+    'name',
+    'number',
+    'callable',
+    'voicemail',
+    'favorite',
+    'email',
+    'personal',
+  ],
+  term: 'a',
+  column_headers: [
+    'Nom',
+    'Num\u00e9ro',
+    'Mobile',
+    'Bo\u00eete vocale',
+    'Favoris',
+    'E-mail',
+    'Personnel',
+  ],
+  results: [],
+};
+
+const contact1 = {
+  source: 'internal',
+  column_values: [
+    'Jonathan Lessard',
+    '8020',
+    '06800880',
+    null,
+    false,
+    'jonathan@example.com',
+    false,
+  ],
+  backend: 'wazo',
+  relations: {
+    user_id: 8,
+    xivo_id: '6cd695d2-cdb9-4444-8b2d-27425ab85fa8',
+    agent_id: null,
+    endpoint_id: 8,
+    user_uuid: 'a14dd6d6-547c-434d-bd5c-e882b5b83b54',
+    source_entry_id: '8',
+  },
+};
+
+const contact2 = {
+  source: 'internal',
+  column_values: [
+    'John Doe',
+    '8021',
+    '06800881',
+    null,
+    false,
+    'john@example.com',
+    false,
+  ],
+  backend: 'wazo',
+  relations: {
+    user_id: 9,
+    xivo_id: '6cd695d2-cdb9-4444-8b2d-27425ab85fa9',
+    agent_id: null,
+    endpoint_id: 9,
+    user_uuid: 'a14dd6d6-547c-434d-bd5c-e882b5b83b55',
+    source_entry_id: '9',
+  },
+};
+
+const parsedContact1 = new Contact({
+  name: 'Jonathan Lessard',
+  number: '8020',
+  numbers: [
+    {
+      label: 'primary',
+      number: '8020',
+    },
+    {
+      label: 'secondary',
+      number: '06800880',
+    },
+  ],
+  favorited: false,
+  email: 'jonathan@example.com',
+  emails: [
+    {
+      label: 'primary',
+      email: 'jonathan@example.com',
+    },
+  ],
+  address: '',
+  entreprise: '',
+  birthday: '',
+  note: '',
+  endpointId: 8,
+  personal: false,
+  source: 'internal',
+  sourceId: '8',
+  uuid: 'a14dd6d6-547c-434d-bd5c-e882b5b83b54',
+  backend: 'wazo',
+});
+
+const parsedContact2 = new Contact({
+  name: 'John Doe',
+  number: '8021',
+  numbers: [
+    {
+      label: 'primary',
+      number: '8021',
+    },
+    {
+      label: 'secondary',
+      number: '06800881',
+    },
+  ],
+  favorited: false,
+  email: 'john@example.com',
+  emails: [
+    {
+      label: 'primary',
+      email: 'john@example.com',
+    },
+  ],
+  address: '',
+  entreprise: '',
+  birthday: '',
+  note: '',
+  endpointId: 9,
+  personal: false,
+  source: 'internal',
+  sourceId: '9',
+  uuid: 'a14dd6d6-547c-434d-bd5c-e882b5b83b55',
+  backend: 'wazo',
+});
+
 describe('Contact domain', () => {
   it('is extern when given no uuid', () => {
     const boba = new Contact({});
@@ -132,10 +265,7 @@ describe('Contact domain', () => {
     const contact = new Contact({
       name: 'John Smith',
     });
-    const {
-      firstName,
-      lastName,
-    } = contact.separateName();
+    const { firstName, lastName } = contact.separateName();
     expect(firstName).toBe('John');
     expect(lastName).toBe('Smith');
   });
@@ -143,10 +273,7 @@ describe('Contact domain', () => {
     const contact = new Contact({
       name: 'John  Smith',
     });
-    const {
-      firstName,
-      lastName,
-    } = contact.separateName();
+    const { firstName, lastName } = contact.separateName();
     expect(firstName).toBe('John');
     expect(lastName).toBe('Smith');
   });
@@ -172,67 +299,81 @@ describe('Contact domain', () => {
   });
   it('can parse a plain contact to domain', () => {
     const response = {
-      column_types: ['name', 'number', 'callable', 'voicemail', 'favorite', 'email', 'personal'],
-      term: 'a',
-      column_headers: ['Nom', 'Num\u00e9ro', 'Mobile', 'Bo\u00eete vocale', 'Favoris', 'E-mail', 'Personnel'],
-      results: [{
-        source: 'internal',
-        column_values: ['Jonathan Lessard', '8020', '06800880', null, false, 'contact@nexapp.ca', false],
-        backend: 'wazo',
-        relations: {
-          user_id: 8,
-          xivo_id: '6cd695d2-cdb9-4444-8b2d-27425ab85fa8',
-          agent_id: null,
-          endpoint_id: 8,
-          user_uuid: 'a14dd6d6-547c-434d-bd5c-e882b5b83b54',
-          source_entry_id: '8',
-        },
-      }],
+      ...genericContactResponse,
+      results: [contact1],
     };
     const contact = Contact.parse(response.results[0], response.column_types);
-    expect(contact).toEqual(new Contact({
-      name: 'Jonathan Lessard',
-      number: '8020',
-      numbers: [{
-        label: 'primary',
-        number: '8020',
-      }, {
-        label: 'secondary',
-        number: '06800880',
-      }],
-      favorited: false,
-      email: 'contact@nexapp.ca',
-      emails: [{
-        label: 'primary',
-        email: 'contact@nexapp.ca',
-      }],
-      address: '',
-      entreprise: '',
-      birthday: '',
-      note: '',
-      endpointId: 8,
-      personal: false,
-      source: 'internal',
-      sourceId: '8',
-      uuid: 'a14dd6d6-547c-434d-bd5c-e882b5b83b54',
-      backend: 'wazo',
-    }));
+    expect(contact).toEqual(parsedContact1);
   });
   it('should merge 2 contact', () => {
-    const contact = new Contact({
+    const noBirthdayContact = new Contact({
       uuid: 'uuid-12345',
       lastActivity: 'yesterday',
       // @ts-expect-error
       birthday: null,
     });
-    const contact2 = new Contact({
+    const noLastActivityContact = new Contact({
       uuid: 'uuid-12345',
       // @ts-expect-error
       lastActivity: null,
       birthday: 'tomorrow',
     });
-    const result = contact.merge(contact2);
+    const result = noBirthdayContact.merge(noLastActivityContact);
     expect(result.lastActivity).toBe('yesterday');
     expect(result.birthday).toBe('tomorrow');
+  });
+  it('returns all contacts when parsing many contacts with no limit', () => {
+    const response = {
+      ...genericContactResponse,
+      results: [contact1, contact2],
+    };
+
+    const contacts = Contact.parseMany(response);
+    expect(contacts).toEqual([parsedContact1, parsedContact2]);
+  });
+  it('returns all contacts when parsing many contacts with a higher limit than number of results', () => {
+    const response = {
+      ...genericContactResponse,
+      results: [contact1, contact2],
+    };
+
+    const contacts = Contact.parseMany(response, 1000);
+    expect(contacts).toEqual([parsedContact1, parsedContact2]);
+  });
+  it('returns limited contacts when parsing many contacts with a smaller limit than number of results', () => {
+    const response = {
+      ...genericContactResponse,
+      results: [contact1],
+    };
+
+    const contacts = Contact.parseMany(response, 1);
+    expect(contacts).toEqual([parsedContact1]);
+  });
+  it('returns all contacts when parsing many contacts with same limit than number of results', () => {
+    const response = {
+      ...genericContactResponse,
+      results: [contact1, contact2],
+    };
+
+    const contacts = Contact.parseMany(response, 2);
+    expect(contacts).toEqual([parsedContact1, parsedContact2]);
+  });
+  it('returns an empty array when parsing many contact with limit of 0', () => {
+    const response = {
+      ...genericContactResponse,
+      results: [contact1, contact2],
+    };
+
+    const contacts = Contact.parseMany(response, 0);
+    expect(contacts).toEqual([]);
+  });
+  it('returns all contacts when parsing many contacts with a negative limit', () => {
+    const response = {
+      ...genericContactResponse,
+      results: [contact1, contact2],
+    };
+
+    const contacts = Contact.parseMany(response, -1);
+    expect(contacts).toEqual([parsedContact1, parsedContact2]);
   });
 });


### PR DESCRIPTION
## Summary of changes
- Makes it possible to limit the number of results returned by the contact search. The backend does not support a `limit` parameter yet, but we can handle it on the front end until that feature is available.