### PR TITLE
Only stop video tracks when stopping screenshare

### DIFF
--- a/src/domain/Phone/WebRTCPhone.ts
+++ b/src/domain/Phone/WebRTCPhone.ts
@@ -515,7 +515,7 @@ export default class WebRTCPhone extends Emitter implements Phone {
     try {
       if (this.currentScreenShare.stream) {
         this.currentScreenShare.stream.getTracks()
-          .filter((track: MediaStreamTrack) => track.enabled)
+          .filter((track: MediaStreamTrack) => track.enabled && track.kind === 'video')
           .forEach((track: MediaStreamTrack) => track.stop());
       }
 


### PR DESCRIPTION
## Summary of changes
- We might sometimes receive an audio track with `enabled` set to `true`. We don't want to stop that audio track when stopping screensharing so we should ensure the track we stop is of the video kind.