### PR TITLE
[NES-2220] expiresAt valid in major browsers

### DIFF
--- a/src/domain/Session.ts
+++ b/src/domain/Session.ts
@@ -1,5 +1,6 @@
 /* eslint-disable no-nested-ternary */
 import { KEYUTIL, KJUR, b64utoutf8 } from 'jsrsasign';
+import moment from 'moment';
 import swarmPublicKey from '../pubkey';
 import Profile from './Profile';
 import Contact from './Contact';
@@ -126,7 +127,7 @@ export default class Session {
       authorizations,
       acl: plain.data.acls ? plain.data.acls : plain.data.acl ? plain.data.acl : [],
       tenantUuid: plain.data.metadata ? plain.data.metadata.tenant_uuid : undefined,
-      expiresAt: new Date(`${plain.data.utc_expires_at}z`),
+      expiresAt: moment.utc(plain.data.utc_expires_at).toDate(),
       stackUuid: plain.data.xivo_uuid,
       // eslint-disable-next-line
       stackHostFromHeader: plain._headers?.get?.('wazo-stack-host'),


### PR DESCRIPTION
## Summary of changes

Make `expiresAt` valid is major browsers. Currently when parsing `utc_expires_at` the output in Firefox or Safari is `Invalid Date`. Since we already have `moment` we should use it to parse API response to a Javascript date