### PR TITLE
[WDA-2366] [WDA-2367] Initiate idp login (SAML)

### DIFF
--- a/src/__tests__/api-client.test.ts
+++ b/src/__tests__/api-client.test.ts
@@ -155,6 +155,28 @@ describe('With correct API results', () => {
   });
 });
 
+describe('initiateIdpAuthentication', () => {
+  it('should make a request to obtain an identity provider URL to redirect to', async () => {
+    const domain = 'example.com';
+    const redirectUrl = 'https://myapp.xyz';
+
+    await client.auth.initiateIdpAuthentication(domain, redirectUrl);
+    expect(global.fetch).toBeCalledWith(`https://${server}/api/auth/${authVersion}/saml/sso`, {
+      method: 'post',
+      body: JSON.stringify({
+        domain,
+        redirect_url: redirectUrl,
+      }),
+      signal: expect.any(Object),
+      headers: {
+        'Content-Type': 'application/json',
+        Accept: 'application/json',
+      },
+      agent: null,
+    });
+  });
+});
+
 describe('With unAuthorized API results', () => {
   beforeEach(() => {
     jest.resetModules();

--- a/src/api/auth.ts
+++ b/src/api/auth.ts
@@ -27,6 +27,7 @@ export interface AuthD {
   logIn(params: LoginParams): Promise<Session | null | undefined> ;
   logOut: (token: Token) => Promise<LogoutResponse>;
   samlLogIn: (samlSessionId: string) => Promise<Session | null | undefined>;
+  initiateIdpAuthentication(domain: string, redirectUrl: string): Promise<any>;
   refreshToken: (refreshToken: string, backend: string, expiration: number, isMobile?: boolean, tenantId?: string, domainName?: string) => Promise<Session | null | undefined>;
   deleteRefreshToken: (clientId: string) => Promise<boolean>;
   updatePassword: (userUuid: UUID, oldPassword: string, newPassword: string) => Promise<boolean>;
@@ -115,6 +116,19 @@ export default ((client: ApiRequester, baseUrl: string): AuthD => ({
     };
 
     return client.post(`${baseUrl}/token`, body).then(Session.parse);
+  },
+  initiateIdpAuthentication: async (domain: string, redirectUrl: string) => {
+    const body = {
+      domain,
+      redirect_url: redirectUrl,
+    };
+
+    const headers = {
+      Accept: 'application/json',
+      'Content-Type': 'application/json',
+    };
+
+    return client.post(`${baseUrl}/saml/sso`, body, headers, (response: any) => response);
   },
   refreshToken: (refreshToken: string, backend: string, expiration: number, isMobile?: boolean, tenantId?: string, domainName?: string): Promise<Session | null | undefined> => {
     const body: Record<string, any> = {

--- a/src/simple/Auth.ts
+++ b/src/simple/Auth.ts
@@ -24,6 +24,7 @@ export class InvalidSubscription extends Error {}
 export class InvalidAuthorization extends Error {}
 export class NoTenantIdError extends Error {}
 export class NoDomainNameError extends Error {}
+export class NoSamlRouteError extends Error {}
 
 const logger = IssueReporter.loggerFor('simple-auth');
 
@@ -163,6 +164,21 @@ export class Auth {
   async samlLogIn(samlSessionId: string): Promise<Session | null> {
     const rawSession = await getApiClient().auth.samlLogIn(samlSessionId);
     return this._onAuthenticated(rawSession as Session);
+  }
+
+  async initiateIdpAuthentication(domain: string, redirectUrl: string): Promise<{ location: string, saml_session_id: string }> {
+    const response = await getApiClient().auth.initiateIdpAuthentication(domain, redirectUrl);
+
+    if (!response.ok) {
+      if (response.status === 404) {
+        throw new NoSamlRouteError('No route found for saml sso');
+      }
+
+      const error = await response.json();
+      throw new Error(error.message || error.reason);
+    }
+
+    return response.json();
   }
 
   async logInViaRefreshToken(refreshToken: string): Promise<Session | null> {

--- a/src/simple/Auth.ts
+++ b/src/simple/Auth.ts
@@ -166,8 +166,14 @@ export class Auth {
     return this._onAuthenticated(rawSession as Session);
   }
 
-  async initiateIdpAuthentication(domain: string, redirectUrl: string): Promise<{ location: string, saml_session_id: string }> {
-    const response = await getApiClient().auth.initiateIdpAuthentication(domain, redirectUrl);
+  async initiateIdpAuthentication(domain: string, redirectUrl: string): Promise<{ location: string, saml_session_id: string } | undefined> {
+    let response;
+    try {
+      response = await getApiClient().auth.initiateIdpAuthentication(domain, redirectUrl);
+    } catch (e: any) {
+      logger.error('Error during IdP authentication initiation:', e.message);
+      return;
+    }
 
     if (!response.ok) {
       if (response.status === 404) {

--- a/src/simple/__tests__/Auth.test.ts
+++ b/src/simple/__tests__/Auth.test.ts
@@ -120,4 +120,95 @@ describe('simple/Auth', () => {
       expect(Auth.onSetUsingEdgeServer).toHaveBeenCalledWith(false);
     });
   });
+
+  describe('initiateIdpAuthentication', () => {
+    const validResponse = { location: 'idp.com/auth', saml_session_id: 'a1b2C3d4' };
+
+    it('should return a `location` and `saml_session_id` if the response is ok', async () => {
+      const initiateIdpAuthentication = jest.fn(() =>
+        Promise.resolve({
+          ok: true,
+          status: 303,
+          json: () => Promise.resolve(validResponse),
+        }));
+
+      (getApiClient as any).mockImplementation(() => ({
+        auth: {
+          initiateIdpAuthentication,
+        },
+      }));
+
+      const response = await Auth.initiateIdpAuthentication('example.com', 'https://myapp.xyz');
+      expect(response).toBe(validResponse);
+    });
+    it('should return a `NoSamlRouteError` if the response is a 404', async () => {
+      const initiateIdpAuthentication = jest.fn(() =>
+        Promise.resolve({
+          ok: false,
+          status: 404,
+        }));
+
+      (getApiClient as any).mockImplementation(() => ({
+        auth: {
+          initiateIdpAuthentication,
+        },
+      }));
+
+      await expect(Auth.initiateIdpAuthentication('example.com', 'https://myapp.xyz')).rejects.toThrow(
+        'No route found for saml sso',
+      );
+    });
+
+    it('should return an error `message` if the response is NOT ok', async () => {
+      const initiateIdpAuthentication = jest.fn(() =>
+        Promise.resolve({
+          ok: false,
+          json: () => Promise.resolve({ message: 'an error message', reason: 'an error reason' }),
+        }));
+
+      (getApiClient as any).mockImplementation(() => ({
+        auth: {
+          initiateIdpAuthentication,
+        },
+      }));
+
+      await expect(Auth.initiateIdpAuthentication('example.com', 'https://myapp.xyz')).rejects.toThrow(
+        'an error message',
+      );
+    });
+
+    it('should return an error `reason` if there is no `message` and the response is NOT ok', async () => {
+      const initiateIdpAuthentication = jest.fn(() =>
+        Promise.resolve({
+          ok: false,
+          json: () => Promise.resolve({ reason: 'an error reason' }),
+        }));
+
+      (getApiClient as any).mockImplementation(() => ({
+        auth: {
+          initiateIdpAuthentication,
+        },
+      }));
+
+      await expect(Auth.initiateIdpAuthentication('example.com', 'https://myapp.xyz')).rejects.toThrow(
+        'an error reason',
+      );
+    });
+
+    it('should return an error with a null message if there is no `message` and `reason`', async () => {
+      const initiateIdpAuthentication = jest.fn(() =>
+        Promise.resolve({
+          ok: false,
+          json: () => Promise.resolve({}),
+        }));
+
+      (getApiClient as any).mockImplementation(() => ({
+        auth: {
+          initiateIdpAuthentication,
+        },
+      }));
+
+      await expect(Auth.initiateIdpAuthentication('example.com', 'https://myapp.xyz')).rejects.toThrow('');
+    });
+  });
 });

--- a/src/simple/index.ts
+++ b/src/simple/index.ts
@@ -1,6 +1,6 @@
 /* eslint-disable import/no-named-as-default */
 /* global window */
-import Auth, { InvalidSubscription, InvalidAuthorization, NoTenantIdError, NoDomainNameError } from './Auth';
+import Auth, { InvalidSubscription, InvalidAuthorization, NoTenantIdError, NoDomainNameError, NoSamlRouteError } from './Auth';
 import Phone from './Phone';
 import Websocket from './Websocket';
 import Room from './room/Room';
@@ -138,6 +138,7 @@ const Wazo = {
   SFUNotAvailableError,
   NoTenantIdError,
   NoDomainNameError,
+  NoSamlRouteError,
 };
 
 if (typeof window !== 'undefined') {


### PR DESCRIPTION
## Summary of changes
- add a method to obtain the `location` and `saml_session_id` from the wazo-auth `saml/sso` route