### PR TITLE
[WP-1177] handle special characters in base64Encode

### DIFF
--- a/src/utils/__tests__/api-requester.test.ts
+++ b/src/utils/__tests__/api-requester.test.ts
@@ -158,3 +158,23 @@ describe('With a refresh token', () => {
     });
   });
 });
+
+describe('base64Encode', () => {
+  it('should encode a string using base64', () => {
+    const input = 'Hello World!';
+    const expectedOutput = 'SGVsbG8gV29ybGQh';
+    expect(ApiRequester.base64Encode(input)).toBe(expectedOutput);
+  });
+
+  it('should handle special characters', () => {
+    const input = 'éà$@€';
+    const expectedOutput = 'w6nDoCRA4oKs';
+    expect(ApiRequester.base64Encode(input)).toBe(expectedOutput);
+  });
+
+  it('should handle empty string', () => {
+    const input = '';
+    const expectedOutput = '';
+    expect(ApiRequester.base64Encode(input)).toBe(expectedOutput);
+  });
+});

--- a/src/utils/api-requester.ts
+++ b/src/utils/api-requester.ts
@@ -64,7 +64,15 @@ export default class ApiRequester {
   }
 
   static base64Encode(str: string): string {
-    return typeof btoa !== 'undefined' ? btoa(str) : Base64.encode(str);
+    if (typeof btoa !== 'undefined') {
+      try {
+        return btoa(str);
+      } catch (error) {
+        // fall back to Base64.encode if btoa fails
+      }
+    }
+
+    return Base64.encode(str);
   }
 
   // @see https://github.com/facebook/flow/issues/183#issuecomment-358607052


### PR DESCRIPTION
## Summary of changes
- Some characters that exceed 1 byte such as `€` would cause the function to throw