### PR TITLE
SAML error handling refactor

### DIFF
--- a/src/api/auth.ts
+++ b/src/api/auth.ts
@@ -139,7 +139,7 @@ export default ((client: ApiRequester, baseUrl: string): AuthD => ({
       'Content-Type': 'application/json',
     };
 
-    return client.post(`${baseUrl}/saml/sso`, body, headers, (response: any) => response);
+    return client.post(`${baseUrl}/saml/sso`, body, headers);
   },
   refreshToken: (refreshToken: string, backend: string, expiration: number, isMobile?: boolean, tenantId?: string, domainName?: string): Promise<Session | null | undefined> => {
     const body: Record<string, any> = {

--- a/src/simple/Auth.ts
+++ b/src/simple/Auth.ts
@@ -168,28 +168,21 @@ export class Auth {
   }
 
   async initiateIdpAuthentication(domain: string, redirectUrl: string): Promise<{ location: string, saml_session_id: string } | undefined> {
-    let response;
     try {
-      response = await getApiClient().auth.initiateIdpAuthentication(domain, redirectUrl);
+      return await getApiClient().auth.initiateIdpAuthentication(domain, redirectUrl);
     } catch (e: any) {
       logger.error('Error during IdP authentication initialization:', e.message);
-      throw e;
-    }
 
-    if (!response.ok) {
-      if (response.status === 404) {
+      if (e.status === 404) {
         throw new NoSamlRouteError('No route found for SAML SSO');
       }
 
-      if (response.status === 500) {
+      if (e.status === 500) {
         throw new SamlConfigError('SAML/server configuration error');
       }
 
-      const error = await response.json();
-      throw new Error(error.message || error.reason);
+      throw e;
     }
-
-    return response.json();
   }
 
   async logInViaRefreshToken(refreshToken: string): Promise<Session | null> {


### PR DESCRIPTION
## Summary of changes
- let the api-requester parse the response
- rely on status from BadResponse or ServerError