### PR TITLE
[WDA-2463] Do not use wss in user agent

### DIFF
--- a/src/web-rtc-client.ts
+++ b/src/web-rtc-client.ts
@@ -2025,9 +2025,6 @@ export default class WebRTCClient extends Emitter {
       authorizationPassword: this.config.password,
       displayName: this.config.displayName,
       hackIpInContact: true,
-      contactParams: {
-        transport: 'wss',
-      },
       logBuiltinEnabled: this.config.log ? this.config.log.builtinEnabled : null,
       logLevel: this.config.log ? this.config.log.logLevel : null,
       logConnector: this.config.log ? this.config.log.connector : null,


### PR DESCRIPTION
## Summary of changes
- We cannot use `wss` as it does not respect the RFC and can cause undesired side effects