### PR TITLE
[WDA-2380] Mark incoming call as forwarded

### DIFF
--- a/src/domain/CallLog.ts
+++ b/src/domain/CallLog.ts
@@ -5,7 +5,7 @@ import type { RecordingResponse } from './Recording';
 import Recording from './Recording';
 
 // note: 24.14 fixes requested (first contact reached) and destination (last contact reached)
-export const CALL_LOG_VALID_RESQUESTED_VERSION = '24.14';
+export const CALL_LOG_VALID_REQUESTED_VERSION = '24.14';
 
 export type CallLogResponse = {
   answer: string | null | undefined;

--- a/src/domain/CallLog.ts
+++ b/src/domain/CallLog.ts
@@ -20,6 +20,7 @@ type CallLogResponse = {
   recordings: RecordingResponse[];
   requested_extension: string;
   requested_name: string;
+  requested_user_uuid: string | null;
   start: string;
 };
 
@@ -32,7 +33,11 @@ type Response = {
 type LogOrigin = {
   extension: string;
   name: string;
-  uuid?: string;
+  uuid?: string | null;
+};
+
+type DestinationLogOrigin = LogOrigin & {
+  plainExtension?: string;
 };
 
 type CallLogArguments = {
@@ -40,7 +45,8 @@ type CallLogArguments = {
   answered: boolean;
   newMissedCall?: boolean;
   callDirection: string;
-  destination: LogOrigin;
+  destination: DestinationLogOrigin;
+  requested: LogOrigin;
   source: LogOrigin;
   id: number;
   duration: number;
@@ -60,7 +66,9 @@ export default class CallLog {
 
   callDirection: string;
 
-  destination: LogOrigin;
+  destination: DestinationLogOrigin;
+
+  requested: LogOrigin;
 
   recordings: Recording[];
 
@@ -99,8 +107,14 @@ export default class CallLog {
         // @TEMP: Temporarily assuming empty numbers are meetings
         // which is admittedly a very dangerous assumption. Did i mention it was temporary?
         extension: plain.requested_extension || plain.destination_extension || `meeting-${plain.requested_name || plain.destination_name || ''}`,
+        plainExtension: plain.destination_extension,
         name: plain.requested_name || plain.destination_name || '',
         uuid: plain.destination_user_uuid,
+      },
+      requested: {
+        extension: plain.requested_extension,
+        name: plain.requested_extension,
+        uuid: plain.requested_user_uuid,
       },
       source: {
         extension: plain.source_extension,
@@ -131,6 +145,7 @@ export default class CallLog {
     answered,
     callDirection,
     destination,
+    requested,
     source,
     id,
     duration,
@@ -142,6 +157,7 @@ export default class CallLog {
     this.answered = answered;
     this.callDirection = callDirection;
     this.destination = destination;
+    this.requested = requested;
     this.source = source;
     this.id = id;
     this.duration = duration;

--- a/src/domain/Session.ts
+++ b/src/domain/Session.ts
@@ -56,8 +56,6 @@ type Authorization = {
 };
 
 type SessionArguments = {
-  acls?: string[];
-  // deprecated
   acl?: string[];
   token: string;
   refreshToken?: string | null | undefined;

--- a/src/domain/__tests__/CallLog.test.ts
+++ b/src/domain/__tests__/CallLog.test.ts
@@ -1,63 +1,191 @@
 import moment from 'moment';
-import CallLog from '../CallLog';
+import CallLog, { Response, CallLogResponse, CALL_LOG_VALID_RESQUESTED_VERSION } from '../CallLog';
 import Recording from '../Recording';
+import Session from '../Session';
+import Profile from '../Profile';
+import Line from '../Line';
 
-describe('CallLog domain', () => {
-  it('can parse a plain call log to domain', () => {
-    const response = {
-      filtered: 6,
-      items: [{
-        answer: moment('2017-08-07T13:51:18.892002+00:00').toDate(),
-        answered: true,
-        call_direction: 'outbound',
-        source_extension: '8020',
-        source_name: 'Jonathan Lessard',
-        source_user_uuid: '123',
-        destination_extension: '4182250459',
-        destination_name: null,
-        destination_user_uuid: '456',
-        duration: 4,
-        start: '2017-08-06T13:50:55.819057+00:00',
-        end: '2017-08-08T13:51:23.822529+00:00',
-        requested_extension: '',
-        requested_name: '',
-        id: 215,
-        recordings: [{
-          deleted: false,
-          end_time: '2021-08-11T13:22:50.519733+00:00',
-          filename: '2021-08-11T13_22_45UTC-61886-xxxx-5c72-4072-8503-e3ad9a41c0a0.wav',
-          start_time: '2021-08-11T13:22:45.161954+00:00',
-          uuid: '0394ad6f-5c72-4072-8503-e3ad9a41c0a0',
+const ALICE_EXTENSION = '41';
+const ALICE_UUID = '11111111-1111-1111-1111-111111111111';
+
+const BOB_EXTENSION = '42';
+const BOB_UUID = '22222222-2222-2222-2222-222222222222';
+
+const CHARLIE_EXTENSION = '43';
+const CHARLIE_UUID = '33333333-3333-3333-3333-333333333333';
+
+// Default scenario: Alice > Bob (No anwser forward) > Charlie
+const CALL_LOG_RESPONSE: CallLogResponse = {
+  id: 1,
+  answer: '2024-01-02T00:00:00.000000+00:00',
+  answered: true,
+  call_direction: 'internal',
+  source_name: 'Alice',
+  source_extension: ALICE_EXTENSION,
+  source_user_uuid: ALICE_UUID,
+  requested_name: 'Bob',
+  requested_extension: BOB_EXTENSION,
+  requested_user_uuid: BOB_UUID,
+  destination_name: 'Charlie',
+  destination_extension: CHARLIE_EXTENSION,
+  destination_user_uuid: CHARLIE_UUID,
+  duration: 4,
+  start: '2024-01-01T00:00:00.000000+00:00',
+  end: '2024-01-01T00:00:04.000000+00:00',
+  recordings: [{
+    uuid: '0394ad6f-5c72-4072-8503-e3ad9a41c0a0',
+    start_time: '2024-01-01T00:00:00.000000+00:00',
+    end_time: '2024-01-01T00:00:04.000000+00:00',
+    filename: '2024-01-01T00_00_04UTC-61886-0394ad6f-5c72-4072-8503-e3ad9a41c0a0.wav',
+    deleted: false,
+  }],
+};
+const CALL_LOG = CallLog.parse(CALL_LOG_RESPONSE);
+
+const generateBobSession = (opts?: Partial<Session>): Session =>
+  new Session({
+    acl: [],
+    token: 'ref-12345',
+    uuid: BOB_UUID,
+    expiresAt: new Date(9999, 0, 1),
+    engineVersion: CALL_LOG_VALID_RESQUESTED_VERSION,
+    profile: new Profile({
+      lines: [new Line({
+        id: 1,
+        extensions: [{
+          id: 1,
+          exten: BOB_EXTENSION,
+          context: 'internal',
         }],
-      }],
-      total: 233,
-    };
-    const logs = CallLog.parseMany(response as any);
-    expect(logs).toEqual([new CallLog({
-      answer: moment('2017-08-07T13:51:18.892002+00:00').toDate(),
-      answered: true,
-      callDirection: 'outbound',
-      destination: {
-        extension: '4182250459',
-        name: '',
-        uuid: '456',
-      },
-      source: {
-        extension: '8020',
-        name: 'Jonathan Lessard',
-        uuid: '123',
-      },
-      id: 215,
-      duration: 4000,
-      start: moment('2017-08-06T13:50:55.819057+00:00').toDate(),
-      end: moment('2017-08-08T13:51:23.822529+00:00').toDate(),
-      recordings: [new Recording({
-        deleted: false,
-        end: moment('2021-08-11T13:22:50.519733+00:00').toDate(),
-        fileName: '2021-08-11T13_22_45UTC-61886-xxxx-5c72-4072-8503-e3ad9a41c0a0.wav',
-        start: moment('2021-08-11T13:22:45.161954+00:00').toDate(),
-        uuid: '0394ad6f-5c72-4072-8503-e3ad9a41c0a0',
       })],
-    })]);
+    } as any),
+    ...(opts || {}),
+  });
+
+const BOB_SESSION = generateBobSession();
+
+describe('CallLog Domain', () => {
+  describe('parseMany', () => {
+    it('can parse a plain call log to domain', () => {
+      const response: Response = {
+        filtered: 6,
+        items: [CALL_LOG_RESPONSE],
+        total: 233,
+      };
+
+      const logs = CallLog.parseMany(response);
+      expect(logs).toEqual([new CallLog({
+        id: 1,
+        answer: moment(CALL_LOG_RESPONSE.answer).toDate(),
+        answered: true,
+        callDirection: 'internal',
+        source: {
+          uuid: ALICE_UUID,
+          name: 'Alice',
+          extension: ALICE_EXTENSION,
+        },
+        requested: {
+          uuid: BOB_UUID,
+          name: 'Bob',
+          extension: BOB_EXTENSION,
+        },
+        destination: {
+          uuid: CHARLIE_UUID,
+          name: 'Bob',
+          extension: BOB_EXTENSION,
+          plainExtension: CHARLIE_EXTENSION,
+          plainName: 'Charlie',
+        },
+        duration: 4000,
+        start: moment(CALL_LOG_RESPONSE.start).toDate(),
+        end: moment(CALL_LOG_RESPONSE.end).toDate(),
+        recordings: [new Recording({
+          uuid: CALL_LOG_RESPONSE.recordings[0].uuid,
+          start: moment(CALL_LOG_RESPONSE.recordings[0].start_time).toDate(),
+          end: moment(CALL_LOG_RESPONSE.recordings[0].end_time).toDate(),
+          fileName: CALL_LOG_RESPONSE.recordings[0].filename,
+          deleted: false,
+        })],
+      })]);
+    });
+  });
+
+  describe('isIconming', () => {
+    it('should be TRUE', () => {
+      // When requested is set to the same user session extension
+      expect(CALL_LOG.isIncomingAndForwarded(BOB_SESSION)).toBe(true);
+
+      // When destination is set to the same user session extension
+      const destinationCallLog = CallLog.parse({
+        ...CALL_LOG_RESPONSE,
+        destination_extension: CALL_LOG_RESPONSE.requested_extension,
+        destination_name: CALL_LOG_RESPONSE.requested_name,
+        destination_user_uuid: CALL_LOG_RESPONSE.requested_user_uuid,
+        requested_extension: CALL_LOG_RESPONSE.destination_extension,
+        requested_name: CALL_LOG_RESPONSE.destination_name,
+        requested_user_uuid: CALL_LOG_RESPONSE.destination_user_uuid,
+      });
+      expect(destinationCallLog.isIncomingAndForwarded(BOB_SESSION)).toBe(true);
+
+      // When call direction is inbound
+      const inboundCallLog = CallLog.parse({ ...CALL_LOG_RESPONSE, call_direction: 'inbound' });
+      expect(inboundCallLog.isIncomingAndForwarded(BOB_SESSION)).toBe(true);
+
+    });
+
+    it('should be FALSE', () => {
+      // When call direction is outbound
+      const outboundCallLog = CallLog.parse({ ...CALL_LOG_RESPONSE, call_direction: 'outbound' });
+      expect(outboundCallLog.isIncomingAndForwarded(BOB_SESSION)).toBe(false);
+    });
+  });
+
+  describe('isIncomingAndForwarded', () => {
+    it('should be TRUE when requested is current user extension and destination is another extesnion', () => {
+      // Internal call (requested contact)
+      expect(CALL_LOG.isIncomingAndForwarded(BOB_SESSION)).toBe(true);
+
+      // Inbound call (requested contact)
+      const inboundCallLog = CallLog.parse({
+        ...CALL_LOG_RESPONSE,
+        call_direction: 'inbound',
+        source_extension: '18004444444',
+        source_name: '',
+        source_user_uuid: null,
+      });
+      expect(inboundCallLog.isIncomingAndForwarded(BOB_SESSION)).toBe(true);
+
+      // Current user is the final destination
+      const destinationCallLog = CallLog.parse({
+        ...CALL_LOG_RESPONSE,
+        destination_extension: CALL_LOG_RESPONSE.requested_extension,
+        destination_name: CALL_LOG_RESPONSE.requested_name,
+        destination_user_uuid: CALL_LOG_RESPONSE.requested_user_uuid,
+        requested_extension: CALL_LOG_RESPONSE.destination_extension,
+        requested_name: CALL_LOG_RESPONSE.destination_name,
+        requested_user_uuid: CALL_LOG_RESPONSE.destination_user_uuid,
+      });
+      expect(destinationCallLog.isIncomingAndForwarded(BOB_SESSION)).toBe(true);
+    });
+
+    it('should be FALSE', () => {
+      // Requested and destination are same
+      const directCallLog = CallLog.parse({
+        ...CALL_LOG_RESPONSE,
+        requested_extension: CALL_LOG_RESPONSE.destination_extension,
+        requested_name: CALL_LOG_RESPONSE.destination_name,
+        requested_user_uuid: CALL_LOG_RESPONSE.destination_user_uuid,
+      });
+
+      expect(directCallLog.isIncomingAndForwarded(BOB_SESSION)).toBe(false);
+
+      // Not incoming call
+      const outboundCallLog = CallLog.parse({ ...CALL_LOG_RESPONSE, call_direction: 'outbound' });
+      expect(outboundCallLog.isIncomingAndForwarded(BOB_SESSION)).toBe(false);
+
+      // Stack version
+      const oldStackSession = generateBobSession({ engineVersion: CALL_LOG_VALID_RESQUESTED_VERSION.replace('14', '10') });
+      expect(CALL_LOG.isIncomingAndForwarded(oldStackSession)).toBe(false);
+    });
   });
 });


### PR DESCRIPTION
## Summary of changes

Introduction new method `isIncomingAndForwarded` for a call log item

Since `24.14`, call log items are more robust about `requested` and `destination` field value
- `requested` will always be the first extension/contact the `source` tried to reach
- `destination` will always be the last extension/contact reached in a call «glow»