### PR TITLE
[WDA-2380] Internal CallLog, also check current user uuid for direction

### DIFF
--- a/src/domain/CallLog.ts
+++ b/src/domain/CallLog.ts
@@ -216,7 +216,10 @@ export default class CallLog {
 
   isIncoming(session: Session): boolean {
     if (this.callDirection === 'internal') {
-      return session.hasExtension(this.destination.plainExtension) || session.hasExtension(this.requested.extension);
+      return session.hasExtension(this.destination.plainExtension)
+        || session.hasExtension(this.requested.extension)
+        || session.uuid === this.destination.uuid
+        || session.uuid === this.requested.uuid;
     }
 
     return this.callDirection === 'inbound';

--- a/src/domain/__tests__/CallLog.test.ts
+++ b/src/domain/__tests__/CallLog.test.ts
@@ -127,6 +127,18 @@ describe('CallLog Domain', () => {
       });
       expect(destinationCallLog.isIncomingAndForwarded(BOB_SESSION)).toBe(true);
 
+      // When destination is set to the same user with a changed extension
+      const destinationExtensionChangedCallLog = CallLog.parse({
+        ...CALL_LOG_RESPONSE,
+        destination_extension: `${CALL_LOG_RESPONSE.requested_extension}9`,
+        destination_name: CALL_LOG_RESPONSE.requested_name,
+        destination_user_uuid: CALL_LOG_RESPONSE.requested_user_uuid,
+        requested_extension: `${CALL_LOG_RESPONSE.destination_extension}9`,
+        requested_name: CALL_LOG_RESPONSE.destination_name,
+        requested_user_uuid: CALL_LOG_RESPONSE.destination_user_uuid,
+      });
+      expect(destinationExtensionChangedCallLog.isIncomingAndForwarded(BOB_SESSION)).toBe(true);
+
       // When call direction is inbound
       const inboundCallLog = CallLog.parse({ ...CALL_LOG_RESPONSE, call_direction: 'inbound' });
       expect(inboundCallLog.isIncomingAndForwarded(BOB_SESSION)).toBe(true);


### PR DESCRIPTION
## Summary of changes

Since API always gives `user_uuid` we should check again this value. Line extension can be changed overtime, but not UUID

Ref Backend Change: https://github.com/wazo-platform/wazo-call-logd/pull/242