### PR TITLE
[WAZO-4003] Allow extend api client

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,9 +146,9 @@ Wazo's Javascript SDK allows you to use these features :
         - [Listening for event](#listening-for-event)
         - [Updating the user token](#updating-the-user-token)
         - [Closing the socket](#closing-the-socket)
-      
-## Install 
- 
+
+## Install
+
 ### Install / Add
 **`Voice`**   **`Video`**  **`Chat`**   **`Fax`**  **`Status`**  **`Config`**   **`Misc`**
 
@@ -181,7 +181,7 @@ import Wazo from '@wazo/sdk';
 // Browser
 // You can access the `Wazo` object directly on the browser, simply include it in the html :
 <script src="https://unpkg.com/@wazo/sdk/dist/wazo-sdk.js"></script>
-or 
+or
 <script src="https://cdn.jsdelivr.net/npm/@wazo/sdk"></script>
 ```
 
@@ -193,17 +193,17 @@ Wazo.Auth.init(clientId, tokenExpiration, minSubscriptionType, authorizationName
 ```
 
 - `clientId`: string (optional)
-  - An identifier of your application that will be used to refresh users token 
-  
+  - An identifier of your application that will be used to refresh users token
+
 - `tokenExpiration`: number (optional, default 3600 seconds)
-  - Duration before token expiration (in seconds) 
-  
+  - Duration before token expiration (in seconds)
+
 - `minSubscriptionType`: number (optional)
   - Defines the minimum user subscription type that allows access to your application.
-  
+
 - `authorizationName`: string (optional)
   - Defines the name of the authorization the user should have to ba able to login.
-  
+
 #### Setting the engine host
 
 ```js
@@ -289,7 +289,7 @@ const session = await Wazo.Auth.validateToken(token, refreshToken);
 
 - `token`: string
   - User's token to validate (eg: makes sure the token is valid and not expired).
-  
+
 - `refreshToken`: string (optional)
   - User's refresh token, used to generate a new token if expired.
 
@@ -328,10 +328,10 @@ Wazo.Room.connect(options);
 - `options`: Object
  - `extension`: string
    The room extension (number) you want to join
- - `audio`: boolean|Object 
+ - `audio`: boolean|Object
    A boolean, if you want to send the user audio or not; or an Object, if you want to specify the audio input, etc...
-   See [getUserMedia arguments](https://developer.mozilla.org/en-US/docs/Web/API/MediaDevices/getUserMedia) for more information. 
- - `video`: boolean|Object 
+   See [getUserMedia arguments](https://developer.mozilla.org/en-US/docs/Web/API/MediaDevices/getUserMedia) for more information.
+ - `video`: boolean|Object
    A boolean, if you want to send the user video or not; or an Object, if you want to specify the audio input, etc...
    See [getUserMedia arguments](https://developer.mozilla.org/en-US/docs/Web/API/MediaDevices/getUserMedia) for more information.
  - `extra`: Object
@@ -347,7 +347,7 @@ room.sendChat(content);
 
 - `content`: string
   The chat message content you want to send to all participants in the room.
-  
+
 #### Sending a custom message to all participants
 
 ```js
@@ -356,15 +356,15 @@ room.sendSignal(content);
 
 - `content`: string
   The message content you want to send to all participants in the room.
-  
+
 #### Sharing the user screen
 
 ```js
 room.startScreenSharing(constraints);
 ```
 
-- `constraints`: Object 
-  See [getUserMedia arguments](https://developer.mozilla.org/en-US/docs/Web/API/MediaDevices/getUserMedia) for more information. 
+- `constraints`: Object
+  See [getUserMedia arguments](https://developer.mozilla.org/en-US/docs/Web/API/MediaDevices/getUserMedia) for more information.
 
 #### Stopping the screen share
 
@@ -469,9 +469,9 @@ Triggered when a participant is talking or stops talking.
 - `channel`: Object containing information about the event.
 - `participant`: `Wazo.RemoteParticipant` or `Wazo.LocalParticipant`.
   The participant instance, you can access the `participant.isTalking` attribute to know the status.
-  
+
 ### Ad hoc Conference features
-**`Voice`**   **`Video`** 
+**`Voice`**   **`Video`**
 
 #### Merging sessions in one conference
 Use this method to merge multiple calls in a new ad hoc conference.
@@ -497,7 +497,7 @@ Use this method to terminate a conference.
 ```js
 adHocConference.hangup();
 ```
-  
+
 ### Accessing the current WebRtc phone
 
 You can access the current [webRtcPhone instance](#WebRTCPhone) via `Wazo.Phone.phone`.
@@ -512,32 +512,32 @@ You can access all Wazo's domain objects in `Wazo.domain.*`, like `Wazo.domain.S
 
 - `uuid`: string
   The participant uuid.
-  
+
 - `name`: string
   The participant name, retrieved from the sip configuration.
-  
+
 - `isTalking`: boolean
   Indicates if the participant is currently talking.
-  
+
 - `streams`: Array of `Wazo.Stream`
   List all streams that the participant is sending.
-  
+
 - `videoStreams`: Array of `Wazo.Stream`
   List all video streams that the participant is sending.
-  
+
 - `audioMuted`: boolean
   Indicates if the participant has muted his microphone.
-  
+
 - `videoMuted`: boolean
   Indicates if the participant has muted his camera.
-  
+
 - `screensharing`: boolean
   Indicates if the participant is currently sharing his screen.
-  
+
 - `extra`: Object
   extra information related to a participant.
-  
-  
+
+
 #### Participant events
 
 ```js
@@ -572,7 +572,7 @@ Triggered when the participant sends a stream.
 
 - `stream`: `Wazo.Stream`
   A Wazo stream that is sent by the participant.
-  
+
 ```js
 participant.on(participant.ON_STREAM_UNSUBSCRIBED, (stream) => {});
 ```
@@ -581,42 +581,42 @@ Triggered when the participant stops sending a stream.
 
 - `stream`: `Wazo.Stream`
   A Wazo stream that is no longer sent by the participant.
-  
+
 ```js
 participant.on(participant.ON_AUDIO_MUTED, () => {});
 ```
 
 Triggered when the participant has disabled his microphone.
-  
+
 ```js
 participant.on(participant.ON_AUDIO_UNMUTED, () => {});
 ```
 
-Triggered when the participant has enabled his microphone. 
-  
+Triggered when the participant has enabled his microphone.
+
 ```js
 participant.on(participant.ON_VIDEO_MUTED, () => {});
 ```
 
-Triggered when the participant has disabled his camera. 
-  
+Triggered when the participant has disabled his camera.
+
 ```js
 participant.on(participant.ON_VIDEO_UNMUTED, () => {});
 ```
 
-Triggered when the participant has enabled his camera. 
-  
+Triggered when the participant has enabled his camera.
+
 ```js
 participant.on(participant.ON_SCREENSHARING, () => {});
 ```
 
-Triggered when the participant is sharing his screen. 
-  
+Triggered when the participant is sharing his screen.
+
 ```js
 participant.on(participant.ON_STOP_SCREENSHARING, () => {});
 ```
 
-Triggered when the participant stops sharing his screen. 
+Triggered when the participant stops sharing his screen.
 
 #### Stream
 
@@ -664,7 +664,7 @@ import { WebRTCClient } from '@wazo/sdk';
 import { WazoWebSocketClient } from '@wazo/sdk';
 ```
 
-### Authentication 
+### Authentication
 #### Initialization
 **`Voice`**   **`Video`**  **`Chat`**   **`Fax`**  **`Status`**  **`Config`**   **`Misc`**
 
@@ -809,7 +809,7 @@ logger(logger.TRACE, 'my log');
 Wazo.IssueReporter.log(Wazo.IssueReporter.INFO, 'my log');
 ```
 
-### Interact with the engine 
+### Interact with the engine
 #### Applicationd
 **`Voice`**   **`Video`**  **`Chat`**   **`Fax`**  **`Status`**  **`Config`**
 
@@ -934,12 +934,12 @@ client.chatd.getMessages(options: GetMessagesOptions);
 ```
 
 #### Calling an API endpoint without WazoApiClient
-**`Voice`**   **`Video`**  **`Chat`**   **`Fax`**  **`Status`**  **`Config`**   **`Misc`**
+**`Config`**   **`Misc`**
 
 Use this generic method to request endpoints directly.
 
 ```js
-const requester = new ApiRequester({ 
+const requester = new ApiRequester({
   server: 'stack.example.com', // Engine server
   refreshTokenCallback: () => {}, // Called when the token is refreshed
   clientId: 'my-id', // ClientId used for refreshToken
@@ -949,7 +949,34 @@ const requester = new ApiRequester({
 
 // Retrieve personal contacts
 const results = await requester.call('dird/0.1/personal');
+```
 
+#### Extending BaseApiClient with you own methods
+**`Config`**   **`Misc`**
+
+WazoApiClient is an extended version of BaseApiClient with needed APIs for softphone users. If you want to add new endpoints and methods it is also possible.
+
+```js
+const myEndpointMethods = (client: ApiRequester, baseUrl: string) => ({
+  getFoo: () => client.get(`${baseUrl}/foo`),
+  postFoo: () => client.post(`${baseUrl}/foo`, { /* body */ }),
+  putFoo: (uuid: string) => client.post(`${baseUrl}/foo/${uuid}`, { /* body */ }),
+  deleteFoo: (uuid: string) => client.delete(`${baseUrl}/foo/${uuid}`),
+});
+
+class CustomApiClient extends BaseApiClient {
+  public myEndpoint;
+
+  constructor(args: ConstructorParams) {
+    super(args);
+    this.initializeEndpoints(); // Reinitialize sdk endpoints
+  }
+
+  initializeEndpoints() {
+    super.initializeEndpoints(); // Include default `auth` methods for token and refresh token mecanism
+    this.myEndpoint = myEndpointMethods(this.client, `confd/1.1`);
+  }
+}
 ```
 
 ### WebRTCClient
@@ -971,7 +998,7 @@ const client = new WebRTCClient({
   }
 }, session);
 
-// eventName can be on the of events : 
+// eventName can be on the of events :
 // - transport: `connected`, `disconnected`, `transportError`, `message`, `closed`, `keepAliveDebounceTimeout`
 // - webrtc: `registered`, `unregistered`, `registrationFailed`, `invite`, `inviteSent`, `transportCreated`, `newTransaction`, `transactionDestroyed`, `notify`, `outOfDialogReferRequested`, `message`.
 client.on('invite', (sipSession: SipSession, hasVideo: boolean, shouldAutoAnswer: boolean) => {
@@ -1004,7 +1031,7 @@ const config = {
   heartbeatDelay: 1000, // Duration in ms between 2 heartbeat (default to 2000)
   heartbeatTimeout: 5000, // Duration in ms when to consider that the Asterisk server is not responding (default to 5000)
   maxHeartbeats: 4, // Number of heatbeat send each time we want to check connection (default to 3)
-  
+
   // When not passing session as second argument:
   authorizationUser: '', // The SIP username
   password: '', // The SIP user password
@@ -1168,7 +1195,7 @@ Use this method to dial a number.
 const callSession = await phone.makeCall(
   number: string, // The number to dial
   line: // Not used
-  enableVideo: boolean // Optional (default to false) when we want to make a video call 
+  enableVideo: boolean // Optional (default to false) when we want to make a video call
 );
 ```
 
@@ -1279,10 +1306,10 @@ phone.indirectTransfer(
 ##### Start screen sharing
 
 ```js
-const screenShareStream: MediaStream = await phone.startScreenSharing({ 
-  audio: true, 
-  video: true, 
-  /* See webRtc media constraints */ 
+const screenShareStream: MediaStream = await phone.startScreenSharing({
+  audio: true,
+  video: true,
+  /* See webRtc media constraints */
 });
 ```
 
@@ -1293,7 +1320,7 @@ phone.stopScreenSharing();
 ```
 
 #### Conference phone features
-**`Voice`**   **`Video`**  **`Chat`** 
+**`Voice`**   **`Video`**  **`Chat`**
 
 ##### Starting a conference
 Use this method to start an ad-hoc conference.
@@ -1402,8 +1429,8 @@ phone.callCount(): number;
 ```
 
 ##### Sending a SIP message
-Sends a SIP MESSAGE in a session. 
-Use `phone.currentSipSession` to retrieve the current `sipSession`. 
+Sends a SIP MESSAGE in a session.
+Use `phone.currentSipSession` to retrieve the current `sipSession`.
 
 ```js
 phone.sendMessage(

--- a/src/api-client.ts
+++ b/src/api-client.ts
@@ -1,4 +1,3 @@
-import authMethods, { AuthD } from './api/auth';
 import applicationMethods, { ApplicationD } from './api/application';
 import confdMethods, { ConfD } from './api/confd';
 import ctidNgMethods, { CtidNg } from './api/ctid-ng';
@@ -9,35 +8,21 @@ import calldMethods, { CallD } from './api/calld';
 import agentdMethods, { AgentD } from './api/agentd';
 import webhookdMethods, { WebhookD } from './api/webhookd';
 import amidMethods, { AmiD } from './api/amid';
-import ApiRequester from './utils/api-requester';
-import IssueReporter from './service/IssueReporter';
-import { obfuscateToken } from './utils/string';
+import {
+  APPLICATION_VERSION,
+  CONFD_VERSION,
+  CTIDNG_VERSION,
+  DIRD_VERSION,
+  CALL_LOGD_VERSION,
+  CHATD_VERSION,
+  CALLD_VERSION,
+  AGENTD_VERSION,
+  WEBHOOKD_VERSION,
+  AMID_VERSION,
+} from './constants';
+import BaseApiClient, { ConstructorParams } from './base-api-client';
 
-type ConstructorParams = {
-  server: string;
-  agent?: Record<string, any> | null | undefined;
-  clientId?: string;
-  refreshToken?: string | null | undefined;
-  isMobile?: boolean | null | undefined;
-  fetchOptions?: Record<string, any>;
-};
-const AUTH_VERSION = '0.1';
-const APPLICATION_VERSION = '1.0';
-const CONFD_VERSION = '1.1';
-const CTIDNG_VERSION = '1.0';
-const DIRD_VERSION = '0.1';
-const CALL_LOGD_VERSION = '1.0';
-const CHATD_VERSION = '1.0';
-const CALLD_VERSION = '1.0';
-const AGENTD_VERSION = '1.0';
-const WEBHOOKD_VERSION = '1.0';
-const AMID_VERSION = '1.0';
-const logger = IssueReporter ? IssueReporter.loggerFor('api') : console;
-export default class ApiClient {
-  client: ApiRequester;
-
-  auth: AuthD;
-
+export default class ApiClient extends BaseApiClient {
   application: ApplicationD;
 
   confd: ConfD;
@@ -58,45 +43,14 @@ export default class ApiClient {
 
   amid: AmiD;
 
-  refreshToken: string | null | undefined;
-
-  onRefreshToken: ((...args: Array<any>) => any) | null | undefined;
-
-  onRefreshTokenError: ((...args: Array<any>) => any) | null | undefined;
-
-  refreshExpiration: number | null | undefined;
-
-  refreshBackend: string | null | undefined;
-
-  refreshTenantId: string | null | undefined;
-
-  refreshDomainName: string | null | undefined;
-
-  isMobile: boolean;
-
-  fetchOptions: Record<string, any>;
-
-  // @see https://github.com/facebook/flow/issues/183#issuecomment-358607052
-  constructor({
-    server,
-    agent = null,
-    refreshToken,
-    clientId,
-    isMobile = false,
-    fetchOptions,
-  }: ConstructorParams) {
-    this.updateParameters({
-      server,
-      agent,
-      clientId,
-      fetchOptions,
-    });
-    this.refreshToken = refreshToken;
-    this.isMobile = isMobile || false;
+  constructor(args: ConstructorParams) {
+    super(args);
+    this.initializeEndpoints(); // Reinitialize sdk endpoints
   }
 
   initializeEndpoints(): void {
-    this.auth = authMethods(this.client, `auth/${AUTH_VERSION}`);
+    super.initializeEndpoints();
+
     this.application = applicationMethods(this.client, `calld/${APPLICATION_VERSION}/applications`);
     this.confd = confdMethods(this.client, `confd/${CONFD_VERSION}`);
     this.ctidNg = ctidNgMethods(this.client, `ctid-ng/${CTIDNG_VERSION}`);
@@ -108,126 +62,4 @@ export default class ApiClient {
     this.webhookd = webhookdMethods(this.client, `webhookd/${WEBHOOKD_VERSION}`);
     this.amid = amidMethods(this.client, `amid/${AMID_VERSION}`);
   }
-
-  updateParameters({
-    server,
-    agent,
-    clientId,
-    fetchOptions,
-  }: Record<string, any>) {
-    const refreshTokenCallback = this.refreshTokenCallback.bind(this);
-    this.client = new ApiRequester({
-      server,
-      agent,
-      refreshTokenCallback,
-      clientId,
-      fetchOptions,
-    });
-    this.initializeEndpoints();
-  }
-
-  async forceRefreshToken(): Promise<string | null> {
-    logger.info('forcing refresh token, calling callback');
-    return this.refreshTokenCallback();
-  }
-
-  async refreshTokenCallback(): Promise<string | null> {
-    logger.info('refresh token callback called', {
-      refreshToken: obfuscateToken(this.refreshToken),
-      refreshBackend: this.refreshBackend,
-      refreshTenantId: this.refreshTenantId,
-      refreshDomainName: this.refreshDomainName,
-      refreshExpiration: this.refreshExpiration,
-      isMobile: this.isMobile,
-    });
-
-    if (!this.refreshToken) {
-      return null;
-    }
-
-    try {
-      const session = await this.auth.refreshToken(this.refreshToken, this.refreshBackend as string, this.refreshExpiration as number, this.isMobile, this.refreshTenantId as string, this.refreshDomainName as string);
-      if (!session) {
-        return null;
-      }
-
-      logger.info('token refreshed', {
-        token: obfuscateToken(session.token),
-      });
-
-      if (this.onRefreshToken) {
-        this.onRefreshToken(session.token, session);
-      }
-
-      this.setToken(session.token);
-      return session.token;
-    } catch (error: any) {
-      logger.error('token refresh, error', error);
-
-      if (this.onRefreshTokenError) {
-        this.onRefreshTokenError(error);
-      }
-    }
-
-    return null;
-  }
-
-  setToken(token: string) {
-    this.client.setToken(token);
-  }
-
-  setTenant(tenant: string) {
-    this.client.setTenant(tenant);
-  }
-
-  setRefreshToken(refreshToken: string | null | undefined) {
-    this.refreshToken = refreshToken;
-  }
-
-  setRequestTimeout(requestTimeout: number) {
-    this.client.setRequestTimeout(requestTimeout);
-  }
-
-  setClientId(clientId: string | null | undefined) {
-    this.client.clientId = clientId;
-  }
-
-  setOnRefreshToken(onRefreshToken: (...args: Array<any>) => any) {
-    this.onRefreshToken = onRefreshToken;
-  }
-
-  setOnRefreshTokenError(callback: (...args: Array<any>) => any) {
-    this.onRefreshTokenError = callback;
-  }
-
-  setRefreshExpiration(refreshExpiration: number) {
-    this.refreshExpiration = refreshExpiration;
-  }
-
-  setRefreshBackend(refreshBackend: string) {
-    this.refreshBackend = refreshBackend;
-  }
-
-  setRefreshTenantId(tenantId: string | null | undefined) {
-    console.warn('Use of `setRefreshTenantId` is deprecated, use `setRefreshDomainName` instead');
-    this.refreshTenantId = tenantId;
-  }
-
-  setRefreshDomainName(domainName: string | null | undefined) {
-    this.refreshDomainName = domainName;
-  }
-
-  setIsMobile(isMobile: boolean) {
-    this.isMobile = isMobile;
-  }
-
-  setFetchOptions(fetchOptions: Record<string, any>) {
-    this.fetchOptions = fetchOptions;
-    this.client.setFetchOptions(fetchOptions);
-  }
-
-  disableErrorLogging() {
-    this.client.disableErrorLogging();
-  }
-
 }

--- a/src/base-api-client.ts
+++ b/src/base-api-client.ts
@@ -1,0 +1,184 @@
+import authMethods, { AuthD } from './api/auth';
+import ApiRequester from './utils/api-requester';
+import IssueReporter from './service/IssueReporter';
+import { obfuscateToken } from './utils/string';
+import { AUTH_VERSION } from './constants';
+
+export type ConstructorParams = {
+  server: string;
+  agent?: Record<string, any> | null | undefined;
+  clientId?: string;
+  refreshToken?: string | null | undefined;
+  isMobile?: boolean | null | undefined;
+  fetchOptions?: Record<string, any>;
+};
+
+const logger = IssueReporter ? IssueReporter.loggerFor('api') : console;
+
+export default class BaseApiClient {
+  client: ApiRequester;
+
+  auth: AuthD;
+
+  refreshToken: string | null | undefined;
+
+  onRefreshToken: ((...args: Array<any>) => any) | null | undefined;
+
+  onRefreshTokenError: ((...args: Array<any>) => any) | null | undefined;
+
+  refreshExpiration: number | null | undefined;
+
+  refreshBackend: string | null | undefined;
+
+  refreshTenantId: string | null | undefined;
+
+  refreshDomainName: string | null | undefined;
+
+  isMobile: boolean;
+
+  fetchOptions: Record<string, any>;
+
+  constructor({
+    server,
+    agent = null,
+    refreshToken,
+    clientId,
+    isMobile = false,
+    fetchOptions,
+  }: ConstructorParams) {
+    this.updateParameters({
+      server,
+      agent,
+      clientId,
+      fetchOptions,
+    });
+    this.refreshToken = refreshToken;
+    this.isMobile = isMobile || false;
+  }
+
+  initializeEndpoints(): void {
+    this.auth = authMethods(this.client, `auth/${AUTH_VERSION}`);
+  }
+
+  updateParameters({
+    server,
+    agent,
+    clientId,
+    fetchOptions,
+  }: Record<string, any>) {
+    const refreshTokenCallback = this.refreshTokenCallback.bind(this);
+    this.client = new ApiRequester({
+      server,
+      agent,
+      refreshTokenCallback,
+      clientId,
+      fetchOptions,
+    });
+    this.initializeEndpoints();
+  }
+
+  async forceRefreshToken(): Promise<string | null> {
+    logger.info('forcing refresh token, calling callback');
+    return this.refreshTokenCallback();
+  }
+
+  async refreshTokenCallback(): Promise<string | null> {
+    logger.info('refresh token callback called', {
+      refreshToken: obfuscateToken(this.refreshToken),
+      refreshBackend: this.refreshBackend,
+      refreshTenantId: this.refreshTenantId,
+      refreshDomainName: this.refreshDomainName,
+      refreshExpiration: this.refreshExpiration,
+      isMobile: this.isMobile,
+    });
+
+    if (!this.refreshToken) {
+      return null;
+    }
+
+    try {
+      const session = await this.auth.refreshToken(this.refreshToken, this.refreshBackend as string, this.refreshExpiration as number, this.isMobile, this.refreshTenantId as string, this.refreshDomainName as string);
+      if (!session) {
+        return null;
+      }
+
+      logger.info('token refreshed', {
+        token: obfuscateToken(session.token),
+      });
+
+      if (this.onRefreshToken) {
+        this.onRefreshToken(session.token, session);
+      }
+
+      this.setToken(session.token);
+      return session.token;
+    } catch (error: any) {
+      logger.error('token refresh, error', error);
+
+      if (this.onRefreshTokenError) {
+        this.onRefreshTokenError(error);
+      }
+    }
+
+    return null;
+  }
+
+  setToken(token: string) {
+    this.client.setToken(token);
+  }
+
+  setTenant(tenant: string) {
+    this.client.setTenant(tenant);
+  }
+
+  setRefreshToken(refreshToken: string | null | undefined) {
+    this.refreshToken = refreshToken;
+  }
+
+  setRequestTimeout(requestTimeout: number) {
+    this.client.setRequestTimeout(requestTimeout);
+  }
+
+  setClientId(clientId: string | null | undefined) {
+    this.client.clientId = clientId;
+  }
+
+  setOnRefreshToken(onRefreshToken: (...args: Array<any>) => any) {
+    this.onRefreshToken = onRefreshToken;
+  }
+
+  setOnRefreshTokenError(callback: (...args: Array<any>) => any) {
+    this.onRefreshTokenError = callback;
+  }
+
+  setRefreshExpiration(refreshExpiration: number) {
+    this.refreshExpiration = refreshExpiration;
+  }
+
+  setRefreshBackend(refreshBackend: string) {
+    this.refreshBackend = refreshBackend;
+  }
+
+  setRefreshTenantId(tenantId: string | null | undefined) {
+    console.warn('Use of `setRefreshTenantId` is deprecated, use `setRefreshDomainName` instead');
+    this.refreshTenantId = tenantId;
+  }
+
+  setRefreshDomainName(domainName: string | null | undefined) {
+    this.refreshDomainName = domainName;
+  }
+
+  setIsMobile(isMobile: boolean) {
+    this.isMobile = isMobile;
+  }
+
+  setFetchOptions(fetchOptions: Record<string, any>) {
+    this.fetchOptions = fetchOptions;
+    this.client.setFetchOptions(fetchOptions);
+  }
+
+  disableErrorLogging() {
+    this.client.disableErrorLogging();
+  }
+
+}

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,0 +1,11 @@
+export const AUTH_VERSION = '0.1';
+export const APPLICATION_VERSION = '1.0';
+export const CONFD_VERSION = '1.1';
+export const CTIDNG_VERSION = '1.0';
+export const DIRD_VERSION = '0.1';
+export const CALL_LOGD_VERSION = '1.0';
+export const CHATD_VERSION = '1.0';
+export const CALLD_VERSION = '1.0';
+export const AGENTD_VERSION = '1.0';
+export const WEBHOOKD_VERSION = '1.0';
+export const AMID_VERSION = '1.0';

--- a/src/index.ts
+++ b/src/index.ts
@@ -48,6 +48,7 @@ export { default as AdHocAPIConference } from './domain/AdHocAPIConference';
 export { default as WebSocketClient, SOCKET_EVENTS } from './websocket-client';
 export { default as WebRTCClient } from './web-rtc-client';
 export { default as WazoApiClient } from './api-client';
+export { default as BaseApiClient } from './base-api-client';
 export { default as Agent, AgentResponse, AgentArguments } from './domain/Agent';
 export { default as ExternalApp } from './domain/ExternalApp';
 export { default as SessionDescriptionHandler } from './lib/WazoSessionDescriptionHandler';

--- a/src/service/__tests__/getApiclient.test.ts
+++ b/src/service/__tests__/getApiclient.test.ts
@@ -1,0 +1,46 @@
+import { ApiRequester, BaseApiClient, WazoApiClient } from '../..';
+import { ConstructorParams } from '../../base-api-client';
+import getApiClient from '../getApiClient';
+
+describe('getApiClient', () => {
+  it('should return WazoApiClient by default', () => {
+    const globalClient = getApiClient();
+    expect(globalClient).toBeInstanceOf(WazoApiClient);
+    expect(globalClient.amid).toBeDefined();
+
+    const serverClient = getApiClient('wazo-platorm.org');
+    expect(serverClient).toBeInstanceOf(WazoApiClient);
+    expect(globalClient.amid).toBeDefined();
+  });
+
+  it.only('should return custom ApiClient', () => {
+    const fooMethods = (client: ApiRequester, baseUrl: string) => ({
+      test: (myString: string) => ({ client, myString, baseUrl }),
+    });
+
+    class FooApiClient extends BaseApiClient {
+      public foo: ReturnType<typeof fooMethods>;
+
+      constructor(args: ConstructorParams) {
+        super(args);
+        this.initializeEndpoints();
+      }
+
+      initializeEndpoints() {
+        super.initializeEndpoints();
+        this.foo = fooMethods(this.client, 'foo/0.1');
+      }
+    }
+
+    const extendedClient = getApiClient<FooApiClient>('foo.wazo-platform.org', FooApiClient);
+    expect(extendedClient).toBeInstanceOf(FooApiClient);
+    expect(extendedClient.auth).toBeDefined();
+    // @ts-ignore: we know amid is undefined, it's important to test it
+    expect(extendedClient.amid).not.toBeDefined();
+
+    const fooTest = extendedClient.foo?.test('foo');
+    expect(fooTest.myString).toBe('foo');
+    expect(fooTest.client).toBeInstanceOf(ApiRequester);
+    expect(fooTest.baseUrl).toBe('foo/0.1');
+  });
+});

--- a/src/utils/api-requester.ts
+++ b/src/utils/api-requester.ts
@@ -75,7 +75,6 @@ export default class ApiRequester {
     return Base64.encode(str);
   }
 
-  // @see https://github.com/facebook/flow/issues/183#issuecomment-358607052
   constructor({
     server,
     refreshTokenCallback,


### PR DESCRIPTION
## Context

`wazo-js-sdk` is very useful for end-user's applications type. But when building an admin application for example, we do not include all admin APIs. So developers needs to use two set of codebase to handle this use case.

We have API Requesters, but this also force developers to loop to each API Requester and initialiser to handle `refreshTokenCallback` mecanism.

## Summary of changes

- Extract `BaseApiClient` class
- `WazoApiClient` now depends on BaseApiClient
- `getApiClient` now accept new parameter for custom ApiClient