### PR TITLE
Encode target before calling UserAgent.makeURI

### DIFF
--- a/src/__tests__/web-rtc-client.test.ts
+++ b/src/__tests__/web-rtc-client.test.ts
@@ -1,12 +1,14 @@
+/* eslint-disable no-underscore-dangle */
+import { UserAgent as UserAgentClass } from 'sip.js';
 import WebRTCClient from '../web-rtc-client';
 
 jest.mock('sip.js/lib/platform/web/transport');
 jest.mock('sip.js/lib/api/user-agent', () => ({
-  start: () => {},
+  start: () => { },
   UserAgent: class UserAgent {
     static makeURI: () => null = () => null;
 
-    start = () => {};
+    start = () => { };
 
     transport = {};
   },
@@ -156,7 +158,8 @@ describe('changeAudioInputDevice', () => {
       };
       client.video = video;
       client.setVideoInputDevice(deviceId);
-      expect(client.video).toEqual({ ...video,
+      expect(client.video).toEqual({
+        ...video,
         deviceId: {
           exact: deviceId,
         },
@@ -193,6 +196,36 @@ describe('changeAudioInputDevice', () => {
           exact: deviceId,
         },
       });
+    });
+  });
+
+  describe('_makeURI', () => {
+    let makeURISpy: jest.SpyInstance;
+
+    beforeEach(() => {
+      jest.clearAllMocks();
+      makeURISpy = jest.spyOn(UserAgentClass, 'makeURI');
+    });
+
+    it('should call UserAgent.makeURI with encoded phone number', () => {
+      const target = '555-123-4567';
+      client._makeURI(target);
+
+      expect(makeURISpy).toHaveBeenCalledWith(`sip:555-123-4567@${client.config.host}`);
+    });
+
+    it('should call UserAgent.makeURI with trimmed phone number', () => {
+      const target = '  1234 5 6789  ';
+      client._makeURI(target);
+
+      expect(makeURISpy).toHaveBeenCalledWith(`sip:123456789@${client.config.host}`);
+    });
+
+    it('should call UserAgent.makeURI with formatted phone number encoded', () => {
+      const target = '1 (800) 555-1234';
+      client._makeURI(target);
+
+      expect(makeURISpy).toHaveBeenCalledWith(`sip:1(800)555-1234@${client.config.host}`);
     });
   });
 });

--- a/src/web-rtc-client.ts
+++ b/src/web-rtc-client.ts
@@ -2470,7 +2470,8 @@ export default class WebRTCClient extends Emitter {
   }
 
   _makeURI(target: string): URI | undefined {
-    return UserAgent.makeURI(`sip:${target}@${this.config.host}`);
+    const encodedTarget = encodeURIComponent(target.replaceAll(' ', ''));
+    return UserAgent.makeURI(`sip:${encodedTarget}@${this.config.host}`);
   }
 
   async _disconnectTransport(force = false) {


### PR DESCRIPTION
- remove all spaces and encode target before using it to make a URI