### PR TITLE
[WAZO-4164] CDR `call_status` and improve listing query params

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -6,6 +6,10 @@ module.exports = {
   transform: {
     '\\.js$': 'babel-jest',
   },
+  testPathIgnorePatterns: [
+    '/node_modules/',
+    '<rootDir>/dist/',
+  ],
   globals: {
     fetch: global.fetch,
     window: {

--- a/src/api/call-logd.ts
+++ b/src/api/call-logd.ts
@@ -1,5 +1,7 @@
 import ApiRequester from '../utils/api-requester';
-import CallLog from '../domain/CallLog';
+import CallLog, { CallLogQueryParams } from '../domain/CallLog';
+
+type ListCallLogsQueryParams = Exclude<CallLogQueryParams, 'offset' | 'limit'>;
 
 export default ((client: ApiRequester, baseUrl: string) => ({
   search: (search: string, limit = 5): Promise<Array<CallLog>> => client.get(`${baseUrl}/users/me/cdr`, {
@@ -12,9 +14,10 @@ export default ((client: ApiRequester, baseUrl: string) => ({
     limit,
   }).then(CallLog.parseMany),
 
-  listCallLogs: (offset?: number, limit = 5): Promise<Array<CallLog>> => client.get(`${baseUrl}/users/me/cdr`, {
+  listCallLogs: (offset?: number, limit = 5, queryParameters: ListCallLogsQueryParams = {}): Promise<Array<CallLog>> => client.get(`${baseUrl}/users/me/cdr`, {
     offset,
     limit,
+    ...queryParameters,
   }).then(CallLog.parseMany),
 
   listDistinctCallLogs: (offset: number, limit = 5, distinct?: string): Promise<Array<CallLog>> => client.get(`${baseUrl}/users/me/cdr`, {

--- a/src/domain/CallLog.ts
+++ b/src/domain/CallLog.ts
@@ -130,7 +130,7 @@ export default class CallLog {
       answer: plain.answer ? moment(plain.answer).toDate() : null,
       answered: plain.answered,
       callDirection: plain.call_direction,
-      callStatus: plain.call_status || 'unknown',
+      callStatus: plain.call_status || (plain?.answered ? 'answered' : 'unknown'),
       destination: {
         // @TEMP: Temporarily assuming empty numbers are meetings
         // which is admittedly a very dangerous assumption. Did i mention it was temporary?

--- a/src/domain/CallLog.ts
+++ b/src/domain/CallLog.ts
@@ -8,9 +8,14 @@ import { ApiParams } from '../types/api';
 // note: 24.14 fixes requested (first contact reached) and destination (last contact reached)
 export const CALL_LOG_VALID_REQUESTED_VERSION = '24.14';
 
+export type CallDirection = 'internal' | 'inbound' | 'outbound';
+
+export type CallStatus = 'answered' | 'blocked' | 'unknown';
+
 export type CallLogResponse = {
   answer: string | null | undefined;
   answered: boolean;
+  call_status: CallStatus;
   call_direction: CallDirection;
   destination_extension: string;
   destination_name: string;
@@ -34,10 +39,6 @@ export type Response = {
   total: number;
 };
 
-export type CallDirection = 'internal' | 'inbound' | 'outbound';
-
-export type CallStatus = 'answered' | 'blocked' | 'unknown';
-
 type LogOrigin = {
   extension: string;
   name: string;
@@ -54,6 +55,7 @@ type CallLogArguments = {
   answered: boolean;
   newMissedCall?: boolean;
   callDirection: CallDirection;
+  callStatus: CallStatus;
   destination: DestinationLogOrigin;
   requested: LogOrigin;
   source: LogOrigin;
@@ -88,6 +90,8 @@ export default class CallLog {
   newMissedCall: boolean;
 
   callDirection: CallDirection;
+
+  callStatus: CallStatus;
 
   destination: DestinationLogOrigin;
 
@@ -126,6 +130,7 @@ export default class CallLog {
       answer: plain.answer ? moment(plain.answer).toDate() : null,
       answered: plain.answered,
       callDirection: plain.call_direction,
+      callStatus: plain.call_status || 'unknown',
       destination: {
         // @TEMP: Temporarily assuming empty numbers are meetings
         // which is admittedly a very dangerous assumption. Did i mention it was temporary?
@@ -168,6 +173,7 @@ export default class CallLog {
     answer,
     answered,
     callDirection,
+    callStatus = 'unknown',
     destination,
     requested,
     source,
@@ -180,6 +186,7 @@ export default class CallLog {
     this.answer = answer;
     this.answered = answered;
     this.callDirection = callDirection;
+    this.callStatus = callStatus;
     this.destination = destination;
     this.requested = requested;
     this.source = source;

--- a/src/domain/CallLog.ts
+++ b/src/domain/CallLog.ts
@@ -3,6 +3,7 @@ import newFrom from '../utils/new-from';
 import Session from './Session';
 import type { RecordingResponse } from './Recording';
 import Recording from './Recording';
+import { ApiParams } from '../types/api';
 
 // note: 24.14 fixes requested (first contact reached) and destination (last contact reached)
 export const CALL_LOG_VALID_REQUESTED_VERSION = '24.14';
@@ -35,6 +36,8 @@ export type Response = {
 
 export type CallDirection = 'internal' | 'inbound' | 'outbound';
 
+export type CallStatus = 'answered' | 'blocked' | 'unknown';
+
 type LogOrigin = {
   extension: string;
   name: string;
@@ -60,6 +63,20 @@ type CallLogArguments = {
   end: Date | null | undefined;
   recordings: Recording[];
 };
+
+type CallLogSpecificQueryParams = {
+  call_direction?: CallDirection;
+  call_status?: CallStatus;
+  number?: string;
+  tags?: string[];
+  user_uuid?: string;
+  from_id?: number;
+  distinct?: string;
+  recorded?: boolean;
+  conversation_id?: string;
+};
+
+export type CallLogQueryParams = ApiParams<CallLogSpecificQueryParams>;
 
 export default class CallLog {
   type: string;

--- a/src/domain/__tests__/CallLog.test.ts
+++ b/src/domain/__tests__/CallLog.test.ts
@@ -19,6 +19,7 @@ const CALL_LOG_RESPONSE: CallLogResponse = {
   id: 1,
   answer: '2024-01-02T00:00:00.000000+00:00',
   answered: true,
+  call_status: 'answered',
   call_direction: 'internal',
   source_name: 'Alice',
   source_extension: ALICE_EXTENSION,
@@ -78,6 +79,7 @@ describe('CallLog Domain', () => {
         id: 1,
         answer: moment(CALL_LOG_RESPONSE.answer).toDate(),
         answered: true,
+        callStatus: 'answered',
         callDirection: 'internal',
         source: {
           uuid: ALICE_UUID,


### PR DESCRIPTION
## Summary of change

- Add the new `call_status` field in CallLog domain
- Allow to pass extra query params when listing call logs.