### PR TITLE
Allow to unset Wazo-Tenant from client

### DIFF
--- a/src/api/application.ts
+++ b/src/api/application.ts
@@ -3,7 +3,7 @@ import ApiRequester from '../utils/api-requester';
 import type { ListNodesResponse, ListCallNodesResponse } from '../domain/types';
 
 export default ((client: ApiRequester, baseUrl: string) => ({
-  bridgeCall(applicationUuid: string, callId: number, context: string, exten: string, autoanswer: string, displayed_caller_id_number: string | null | undefined): Promise<boolean> {
+  bridgeCall(applicationUuid: string, callId: number, context: string, exten: string, autoanswer: string, displayed_caller_id_number: string | null | undefined): Promise<Record<string, any>> {
     const url = `${baseUrl}/${applicationUuid}/nodes`;
     const body = {
       calls: [{

--- a/src/api/calld.ts
+++ b/src/api/calld.ts
@@ -119,6 +119,7 @@ export default ((client: ApiRequester, baseUrl: string) => ({
       extension,
       caller_id: callerId,
     });
+
     return client.post(`${baseUrl}/users/me/faxes?${params}`, fax, headers);
   },
 

--- a/src/api/confd.ts
+++ b/src/api/confd.ts
@@ -84,7 +84,7 @@ export default ((client: ApiRequester, baseUrl: string) => ({
     }
   },
 
-  getMyMeetings: (): Promise<Meeting> => client.get(`${baseUrl}/users/me/meetings`).then((response: any) => Meeting.parseMany(response.items)),
+  getMyMeetings: (): Promise<Meeting[]> => client.get(`${baseUrl}/users/me/meetings`).then((response: any) => Meeting.parseMany(response.items)),
 
   createMyMeeting: (args: MeetingCreateArguments): Promise<Meeting> => client.post(`${baseUrl}/users/me/meetings`, convertKeysFromCamelToUnderscore(args)).then(Meeting.parse),
 

--- a/src/api/dird.ts
+++ b/src/api/dird.ts
@@ -20,7 +20,7 @@ export default ((client: ApiRequester, baseUrl: string) => ({
     term,
   }).then((response: ContactsResponse) => Contact.parseMany(response, offset, limit)),
 
-  listPersonalContacts: (queryParams?: QueryParams): Promise<Array<Contact>> => client.get(`${baseUrl}/personal`, queryParams).then((response: any) => Contact.parseManyPersonal(response.items)),
+  listPersonalContacts: (queryParams?: QueryParams): Promise<Contact[]> => client.get(`${baseUrl}/personal`, queryParams).then((response: any) => Contact.parseManyPersonal(response.items)),
 
   fetchPersonalContact: (contactUuid: string): Promise<Contact> => client.get(`${baseUrl}/personal/${contactUuid}`).then(Contact.parsePersonal),
 

--- a/src/domain/Contact.ts
+++ b/src/domain/Contact.ts
@@ -428,7 +428,7 @@ export default class Contact {
     });
   }
 
-  static parseManyPersonal(results: Array<ContactPersonalResponse>): Array<Contact | null | undefined> {
+  static parseManyPersonal(results: Array<ContactPersonalResponse>): Contact[] {
     return results.map(r => Contact.parsePersonal(r));
   }
 


### PR DESCRIPTION
## Summary of change

Few admin's API do not allow to pass Wazo-Tenant in the headers. Until now, the SDK was not able to handle this case.

Example how to unset the tenant for a single call
```
getApiClient().client.get('auth/0.1/users', null, {  'Wazo-Tenant': false });

// Instead of

```