### PR TITLE
build: use types from 25.08 + node requirements

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "prepublishOnly": "pnpm build"
   },
   "dependencies": {
-    "@wazo/types": "^25.7.3",
+    "@wazo/types": "^25.8.0",
     "events": "^3.3.0",
     "fstream": "^1.0.12",
     "getstats": "wazo-platform/getStats#1.0.7",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,8 +12,8 @@ importers:
   .:
     dependencies:
       '@wazo/types':
-        specifier: ^25.7.3
-        version: 25.7.3
+        specifier: ^25.8.0
+        version: 25.8.0
       events:
         specifier: ^3.3.0
         version: 3.3.0
@@ -1120,9 +1120,9 @@ packages:
   '@ungap/structured-clone@1.3.0':
     resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
 
-  '@wazo/types@25.7.3':
-    resolution: {integrity: sha512-C0sOB8dbDbvtAIQk5g0+DhpAXhlztzguAVJWf0Qw5bjp2MSrDpufJcq2w6tj/1v1V0Vve6GxHV7pS6GyPI2QOw==}
-    engines: {node: 22.x}
+  '@wazo/types@25.8.0':
+    resolution: {integrity: sha512-ezNozqFgW7X6DTNFz05MGCs4+XbZocxaZ2h7smrCQ1Fgwp3gyCuQ10HQt/NkP6mH6E1AMqMrkneijUxL3VcjZQ==}
+    engines: {node: '>=18.0.0'}
 
   '@webassemblyjs/ast@1.14.1':
     resolution: {integrity: sha512-nuBEDgQfm1ccRp/8bCQrx1frohyufl4JlbMMZ4P1wpeOfDhF6FQkxZJ1b/e+PLwr6X1Nhw6OLme5usuBWYBvuQ==}
@@ -4700,7 +4700,7 @@ snapshots:
 
   '@ungap/structured-clone@1.3.0': {}
 
-  '@wazo/types@25.7.3': {}
+  '@wazo/types@25.8.0': {}
 
   '@webassemblyjs/ast@1.14.1':
     dependencies:


### PR DESCRIPTION
## Summary of changes

- Use latest types
- Use latest required of node (now match wazo-js-sdk)