### PR TITLE
ITEM-450 pre-generate-call-id

### DIFF
--- a/src/domain/Phone/WebRTCPhone.ts
+++ b/src/domain/Phone/WebRTCPhone.ts
@@ -1839,8 +1839,11 @@ export default class WebRTCPhone extends Emitter implements Phone {
     } = sipSession || {};
     const sessionId = this.getSipSessionId(sipSession);
     fromSession = fromSession || this.callSessions[sessionId];
+    // wazo-calld exposes the channel id of our own leg in the INVITE, so the
+    // Wazo call id is known without having to fetch GET /users/me/calls.
+    const headerCallId = sipSession?.request?.getHeader?.('X-Wazo-Call-ID');
     const callSession = new CallSession({
-      callId: fromSession && fromSession.callId,
+      callId: fromSession?.callId || headerCallId || '',
       sipCallId: sessionId,
       sipStatus: state,
       displayName: identity ? identity.displayName || number : number,

--- a/src/domain/Phone/__tests__/WebRTCPhone.test.ts
+++ b/src/domain/Phone/__tests__/WebRTCPhone.test.ts
@@ -115,6 +115,47 @@ describe('WebRTCPhone._createCallSession diversion', () => {
   });
 });
 
+describe('WebRTCPhone._createCallSession callId', () => {
+  const requestWithHeader = (value?: string) => ({ getHeader: (name: string) => (name === 'X-Wazo-Call-ID' ? value : undefined) });
+
+  it('maps the X-Wazo-Call-ID header of the INVITE to callId', () => {
+    const sipSession = { id: 'session-1', request: requestWithHeader('1719843012.42') } as any;
+    const phone = createPhone(createCreatableMockClient({ 'session-1': sipSession }));
+
+    const cs = phone._createCallSession(sipSession);
+
+    expect(cs.callId).toBe('1719843012.42');
+  });
+
+  it('keeps the callId of the previous call session over the header', () => {
+    const sipSession = { id: 'session-1', request: requestWithHeader('1719843012.42') } as any;
+    const phone = createPhone(createCreatableMockClient({ 'session-1': sipSession }));
+    const fromSession = new CallSession({ callId: 'existing-id', sipCallId: 'session-1' } as any);
+
+    const cs = phone._createCallSession(sipSession, fromSession);
+
+    expect(cs.callId).toBe('existing-id');
+  });
+
+  it('is empty without header nor previous call session', () => {
+    const sipSession = { id: 'session-1', request: requestWithHeader(undefined) } as any;
+    const phone = createPhone(createCreatableMockClient({ 'session-1': sipSession }));
+
+    const cs = phone._createCallSession(sipSession);
+
+    expect(cs.callId).toBe('');
+  });
+
+  it('supports sip sessions without a request object', () => {
+    const sipSession = { id: 'session-1' } as any;
+    const phone = createPhone(createCreatableMockClient({ 'session-1': sipSession }));
+
+    const cs = phone._createCallSession(sipSession);
+
+    expect(cs.callId).toBe('');
+  });
+});
+
 describe('WebRTCPhone._createCallSession assertedIdentity', () => {
   // Shaped like sip.js's `Session.assertedIdentity` (a parsed NameAddrHeader).
   // The URI exposes the user via the public `user` getter and the private


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches how `callId` is bound to active calls before REST calld APIs run; wrong or missing ids could break mute/hold-style API calls, though existing ids are preserved and the SIP header path is additive.
> 
> **Overview**
> **Call sessions can carry the Wazo `callId` earlier**, so calld REST actions (e.g. mute/unmute) can run without listing `GET /users/me/calls`.
> 
> For **incoming** calls, `_createCallSession` now seeds `callId` from the SIP INVITE header `X-Wazo-Call-ID` when there is no prior session value. For **outgoing** calls (and any leg that still lacks an id), `WebRTCPhone.setCallSessionCallId` sets `callId` from websocket `call_created` data (`sip_call_id` → `call_id`), without overwriting an id that is already set.
> 
> The simple `Phone` wrapper registers `CALL_CREATED` on connect and unregisters on disconnect, wiring events into `setCallSessionCallId`. Unit tests cover header mapping, precedence over the header, and the setter’s no-overwrite behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit edecb42b24fc8d7f9f0ffda6bad67641ffc9d730. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->