### PR TITLE
[ITEM-444] Enforce a single UserAgent per WebRTC client

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,8 +40,7 @@
     "format": "pnpm format:file \"src/**/*.(ts|js)\" \"__tests__/**/*.(ts|js)\"",
     "format:file": "prettier-eslint --write --single-quote --trailing-comma=es5 --arrow-parens=avoid",
     "typecheck": "tsc --noEmit",
-    "prepare": "pnpm build",
-    "prepublishOnly": "pnpm build"
+    "prepare": "pnpm build"
   },
   "dependencies": {
     "@wazo/types": "^25.16.1",

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "format": "pnpm format:file \"src/**/*.(ts|js)\" \"__tests__/**/*.(ts|js)\"",
     "format:file": "prettier-eslint --write --single-quote --trailing-comma=es5 --arrow-parens=avoid",
     "typecheck": "tsc --noEmit",
+    "prepare": "pnpm build",
     "prepublishOnly": "pnpm build"
   },
   "dependencies": {

--- a/src/__tests__/web-rtc-client-multi-client.test.ts
+++ b/src/__tests__/web-rtc-client-multi-client.test.ts
@@ -1,0 +1,67 @@
+import WebRTCClient from '../web-rtc-client';
+
+const mockUaInstances: any[] = [];
+
+jest.mock('sip.js/lib/platform/web/transport');
+jest.mock('sip.js/lib/api/user-agent', () => ({
+  UserAgent: class UserAgent {
+    static makeURI: () => null = () => null;
+
+    start = jest.fn(() => Promise.resolve());
+
+    stop = jest.fn(() => Promise.resolve());
+
+    transport = {};
+
+    constructor() {
+      mockUaInstances.push(this);
+    }
+  },
+}));
+
+const liveUas = () => mockUaInstances.filter(ua => ua.stop.mock.calls.length === 0);
+
+describe('single UserAgent per WebRTCClient', () => {
+  beforeEach(() => {
+    mockUaInstances.length = 0;
+    jest.restoreAllMocks();
+  });
+
+  it('does not leak a UserAgent when register() runs before _buildConfig resolves', async () => {
+    let resolveBuildConfig: (config: any) => void = () => {};
+    jest.spyOn(WebRTCClient.prototype as any, '_buildConfig').mockReturnValue(new Promise(resolve => {
+      resolveBuildConfig = resolve;
+    }));
+    // Keep register() pending after it created its UserAgent
+    jest.spyOn(WebRTCClient.prototype as any, '_connectIfNeeded').mockReturnValue(new Promise(() => {}));
+
+    const client = new WebRTCClient({} as any, { token: 'token', refreshToken: 'refresh', uuid: 'uuid' } as any, undefined);
+
+    client.register();
+
+    expect(mockUaInstances.length).toBe(1);
+
+    // Constructor's _buildConfig resolves after register() already created a UserAgent
+    resolveBuildConfig({});
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(liveUas().length).toBe(1);
+    expect(client.userAgent).toBe(liveUas()[0]);
+  });
+
+  it('stops an existing UserAgent before creating a new one', () => {
+    const client = new WebRTCClient({} as any, undefined, undefined);
+    const oldUa: any = {
+      stop: jest.fn(() => Promise.resolve()),
+      start: jest.fn(() => Promise.resolve()),
+      transport: {},
+    };
+    client.userAgent = oldUa;
+
+    const newUa = client.createUserAgent();
+
+    expect(oldUa.stop).toHaveBeenCalled();
+    expect(newUa).not.toBe(oldUa);
+  });
+});

--- a/src/__tests__/web-rtc-client-multi-client.test.ts
+++ b/src/__tests__/web-rtc-client-multi-client.test.ts
@@ -1,3 +1,5 @@
+import { RegistererState } from 'sip.js/lib/api/registerer-state';
+
 import WebRTCClient from '../web-rtc-client';
 
 const mockUaInstances: any[] = [];
@@ -63,5 +65,28 @@ describe('single UserAgent per WebRTCClient', () => {
 
     expect(oldUa.stop).toHaveBeenCalled();
     expect(newUa).not.toBe(oldUa);
+  });
+});
+
+describe('unregister', () => {
+  it('removes its stateChange listener once unregistered', async () => {
+    const client = new WebRTCClient({} as any, undefined, undefined);
+    const listeners: Array<(state: string) => void> = [];
+    const registerer: any = {
+      stateChange: {
+        addListener: jest.fn((fn: (state: string) => void) => listeners.push(fn)),
+        removeListener: jest.fn(),
+        removeAllListeners: jest.fn(),
+      },
+      unregister: jest.fn(() => Promise.resolve()),
+    };
+    client.registerer = registerer;
+
+    const promise = client.unregister();
+    listeners[0](RegistererState.Unregistered);
+    await promise;
+
+    expect(registerer.stateChange.addListener).toHaveBeenCalledTimes(1);
+    expect(registerer.stateChange.removeListener).toHaveBeenCalledWith(listeners[0]);
   });
 });

--- a/src/__tests__/web-rtc-client-multi-client.test.ts
+++ b/src/__tests__/web-rtc-client-multi-client.test.ts
@@ -1,4 +1,5 @@
 import { RegistererState } from 'sip.js/lib/api/registerer-state';
+import { TransportState } from 'sip.js/lib/api/transport-state';
 
 import WebRTCClient, { getLiveClientCount } from '../web-rtc-client';
 
@@ -17,7 +18,7 @@ jest.mock('sip.js/lib/api/user-agent', () => ({
 
     onTransportMessage = jest.fn();
 
-    transport = { disconnect: jest.fn(() => Promise.resolve()) };
+    transport = { disconnect: jest.fn(() => Promise.resolve()), state: 'Connected', transitionState: jest.fn() };
 
     stateChange = { removeAllListeners: jest.fn() };
 
@@ -37,7 +38,7 @@ describe('single UserAgent per WebRTCClient', () => {
     jest.restoreAllMocks();
   });
 
-  it('does not leak a UserAgent when register() runs before _buildConfig resolves', async () => {
+  it('recreates the UA with the fetched session config when register() raced _buildConfig', async () => {
     let resolveBuildConfig: (config: any) => void = () => {};
     jest.spyOn(WebRTCClient.prototype as any, '_buildConfig').mockReturnValue(new Promise(resolve => {
       resolveBuildConfig = resolve;
@@ -51,13 +52,55 @@ describe('single UserAgent per WebRTCClient', () => {
 
     expect(mockUaInstances).toHaveLength(1);
 
-    // Constructor's _buildConfig resolves after register() already created a UserAgent
+    // Constructor's _buildConfig resolves after register() already created a UserAgent:
+    // the racing UA was built without the fetched credentials, so it must be replaced
+    // (stopping the old one) — never left as a leaked second UA.
+    resolveBuildConfig({ authorizationUser: 'user', password: 'secret' });
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(mockUaInstances).toHaveLength(2);
+    expect(liveUas()).toHaveLength(1);
+    expect(client.userAgent).toBe(mockUaInstances[1]);
+    expect((client.config as any).authorizationUser).toBe('user');
+  });
+
+  it('keeps the UA created by register() when there is no session (config unchanged)', async () => {
+    let resolveBuildConfig: (config: any) => void = () => {};
+    jest.spyOn(WebRTCClient.prototype as any, '_buildConfig').mockReturnValue(new Promise(resolve => {
+      resolveBuildConfig = resolve;
+    }));
+    jest.spyOn(WebRTCClient.prototype as any, '_connectIfNeeded').mockReturnValue(new Promise(() => {}));
+
+    const client = new WebRTCClient({} as any, undefined, undefined);
+
+    client.register();
+
+    expect(mockUaInstances).toHaveLength(1);
+
     resolveBuildConfig({});
     await Promise.resolve();
     await Promise.resolve();
 
-    expect(liveUas()).toHaveLength(1);
-    expect(client.userAgent).toBe(liveUas()[0]);
+    expect(mockUaInstances).toHaveLength(1);
+    expect(client.userAgent).toBe(mockUaInstances[0]);
+  });
+
+  it('does not create a UA when close() ran before _buildConfig resolved', async () => {
+    let resolveBuildConfig: (config: any) => void = () => {};
+    jest.spyOn(WebRTCClient.prototype as any, '_buildConfig').mockReturnValue(new Promise(resolve => {
+      resolveBuildConfig = resolve;
+    }));
+
+    const client = new WebRTCClient({ media: {} } as any, { token: 'token', refreshToken: 'refresh', uuid: 'uuid' } as any, undefined);
+    await client.close();
+
+    resolveBuildConfig({});
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(mockUaInstances).toHaveLength(0);
+    expect(client.userAgent).toBeFalsy();
   });
 
   it('stops an existing UserAgent before creating a new one', () => {
@@ -144,7 +187,49 @@ describe('zombie registration (registered but transport dead)', () => {
 
     expect(client.registerer).toBeNull();
     expect(disconnectSpy).toHaveBeenCalledWith(true); // force-close the dead socket
+    // sip.js reports Connected until the WS close event fires — the state must be forced
+    // so _connectIfNeeded() reconnects instead of REGISTERing into the dying socket.
+    expect((client.userAgent as any).transport.transitionState).toHaveBeenCalledWith(TransportState.Disconnected);
     expect(connectSpy).toHaveBeenCalled();
+  });
+
+  it('dedupes concurrent register() calls during the heal', async () => {
+    const client = new WebRTCClient({ transportSilenceThresholdMs: 65000 } as any, undefined, undefined);
+    await flushMicrotasks();
+    (client.userAgent as any).isConnected.mockReturnValue(true);
+    client.lastTransportMessageAt = Date.now() - 120000;
+    client.registerer = { state: RegistererState.Registered, stateChange: { removeAllListeners: jest.fn() } } as any;
+    const connectSpy = jest.spyOn(client as any, '_connectIfNeeded').mockReturnValue(new Promise(() => {}));
+
+    client.register();
+    client.register(); // enters while the first is awaiting the forced disconnect
+    await flushMicrotasks();
+
+    expect(connectSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('is not suspect without a threshold configured, even when silent', async () => {
+    const client = await makeClient();
+    (client.userAgent as any).isConnected.mockReturnValue(true);
+    client.lastTransportMessageAt = Date.now() - 600000;
+
+    expect(client.isTransportSuspect()).toBe(false);
+  });
+
+  it('is not suspect when no message was ever received (fresh connection)', async () => {
+    const client = new WebRTCClient({ transportSilenceThresholdMs: 65000 } as any, undefined, undefined);
+    await flushMicrotasks();
+    (client.userAgent as any).isConnected.mockReturnValue(true);
+
+    expect(client.getLastTransportMessageAt()).toBeNull();
+    expect(client.isTransportSuspect()).toBe(false);
+  });
+
+  it('is suspect when the transport is disconnected', async () => {
+    const client = await makeClient();
+    (client.userAgent as any).isConnected.mockReturnValue(false);
+
+    expect(client.isTransportSuspect()).toBe(true);
   });
 
   it('is not suspect while sip sessions are active, even with silent transport', async () => {

--- a/src/__tests__/web-rtc-client-multi-client.test.ts
+++ b/src/__tests__/web-rtc-client-multi-client.test.ts
@@ -1,6 +1,6 @@
 import { RegistererState } from 'sip.js/lib/api/registerer-state';
 
-import WebRTCClient from '../web-rtc-client';
+import WebRTCClient, { getLiveClientCount } from '../web-rtc-client';
 
 const mockUaInstances: any[] = [];
 
@@ -13,7 +13,11 @@ jest.mock('sip.js/lib/api/user-agent', () => ({
 
     stop = jest.fn(() => Promise.resolve());
 
-    transport = {};
+    transport = { disconnect: jest.fn(() => Promise.resolve()) };
+
+    stateChange = { removeAllListeners: jest.fn() };
+
+    delegate: any;
 
     constructor() {
       mockUaInstances.push(this);
@@ -65,6 +69,25 @@ describe('single UserAgent per WebRTCClient', () => {
 
     expect(oldUa.stop).toHaveBeenCalled();
     expect(newUa).not.toBe(oldUa);
+  });
+});
+
+describe('live client counter', () => {
+  it('tracks alive clients and decrements once on close', async () => {
+    const before = getLiveClientCount();
+    const clientA = new WebRTCClient({ media: {} } as any, undefined, undefined);
+    const clientB = new WebRTCClient({ media: {} } as any, undefined, undefined);
+
+    expect(getLiveClientCount()).toBe(before + 2);
+
+    await clientA.close();
+    await clientA.close();
+
+    expect(getLiveClientCount()).toBe(before + 1);
+
+    await clientB.close();
+
+    expect(getLiveClientCount()).toBe(before);
   });
 });
 

--- a/src/__tests__/web-rtc-client-multi-client.test.ts
+++ b/src/__tests__/web-rtc-client-multi-client.test.ts
@@ -49,14 +49,14 @@ describe('single UserAgent per WebRTCClient', () => {
 
     client.register();
 
-    expect(mockUaInstances.length).toBe(1);
+    expect(mockUaInstances).toHaveLength(1);
 
     // Constructor's _buildConfig resolves after register() already created a UserAgent
     resolveBuildConfig({});
     await Promise.resolve();
     await Promise.resolve();
 
-    expect(liveUas().length).toBe(1);
+    expect(liveUas()).toHaveLength(1);
     expect(client.userAgent).toBe(liveUas()[0]);
   });
 

--- a/src/__tests__/web-rtc-client-multi-client.test.ts
+++ b/src/__tests__/web-rtc-client-multi-client.test.ts
@@ -130,6 +130,33 @@ describe('zombie registration (registered but transport dead)', () => {
     expect(connectSpy).not.toHaveBeenCalled();
   });
 
+  it('re-registers when the socket is half-open (connected but silent too long)', async () => {
+    const client = new WebRTCClient({ transportSilenceThresholdMs: 65000 } as any, undefined, undefined);
+    await flushMicrotasks();
+    (client.userAgent as any).isConnected.mockReturnValue(true);
+    client.lastTransportMessageAt = Date.now() - 120000;
+    client.registerer = { state: RegistererState.Registered, stateChange: { removeAllListeners: jest.fn() } } as any;
+    const disconnectSpy = jest.spyOn(client as any, '_disconnectTransport');
+    const connectSpy = jest.spyOn(client as any, '_connectIfNeeded').mockReturnValue(new Promise(() => {}));
+
+    client.register();
+    await flushMicrotasks();
+
+    expect(client.registerer).toBeNull();
+    expect(disconnectSpy).toHaveBeenCalledWith(true); // force-close the dead socket
+    expect(connectSpy).toHaveBeenCalled();
+  });
+
+  it('is not suspect while sip sessions are active, even with silent transport', async () => {
+    const client = new WebRTCClient({ transportSilenceThresholdMs: 65000 } as any, undefined, undefined);
+    await flushMicrotasks();
+    (client.userAgent as any).isConnected.mockReturnValue(true);
+    client.lastTransportMessageAt = Date.now() - 120000;
+    client.sipSessions = { 'session-1': {} as any };
+
+    expect(client.isTransportSuspect()).toBe(false);
+  });
+
   it('tracks the last inbound transport message timestamp', async () => {
     const client = await makeClient();
 

--- a/src/__tests__/web-rtc-client-multi-client.test.ts
+++ b/src/__tests__/web-rtc-client-multi-client.test.ts
@@ -65,6 +65,28 @@ describe('single UserAgent per WebRTCClient', () => {
     expect((client.config as any).authorizationUser).toBe('user');
   });
 
+  it('drops a registerer bound to the replaced UA when the session race resolves', async () => {
+    let resolveBuildConfig: (config: any) => void = () => {};
+    jest.spyOn(WebRTCClient.prototype as any, '_buildConfig').mockReturnValue(new Promise(resolve => {
+      resolveBuildConfig = resolve;
+    }));
+    jest.spyOn(WebRTCClient.prototype as any, '_connectIfNeeded').mockReturnValue(new Promise(() => {}));
+
+    const client = new WebRTCClient({} as any, { token: 'token', refreshToken: 'refresh', uuid: 'uuid' } as any, undefined);
+
+    client.register();
+    // Simulate the racing register() having bound a registerer to the first UA
+    client.registerer = { stateChange: { removeAllListeners: jest.fn() } } as any;
+
+    resolveBuildConfig({ authorizationUser: 'user', password: 'secret' });
+    await Promise.resolve();
+    await Promise.resolve();
+
+    // The registerer pointed at the stopped UA; it must not linger
+    expect(client.registerer).toBeNull();
+    expect(client.userAgent).toBe(mockUaInstances[1]);
+  });
+
   it('keeps the UA created by register() when there is no session (config unchanged)', async () => {
     let resolveBuildConfig: (config: any) => void = () => {};
     jest.spyOn(WebRTCClient.prototype as any, '_buildConfig').mockReturnValue(new Promise(resolve => {
@@ -136,6 +158,23 @@ describe('live client counter', () => {
 
     expect(getLiveClientCount()).toBe(before);
   });
+
+  it('counts a revived client as live again when register() runs after close()', async () => {
+    const before = getLiveClientCount();
+    const client = new WebRTCClient({ media: {} } as any, undefined, undefined);
+    await client.close();
+
+    expect(getLiveClientCount()).toBe(before);
+
+    jest.spyOn(client as any, '_connectIfNeeded').mockReturnValue(new Promise(() => {}));
+    client.register();
+
+    expect(getLiveClientCount()).toBe(before + 1);
+
+    await client.close();
+
+    expect(getLiveClientCount()).toBe(before);
+  });
 });
 
 describe('zombie registration (registered but transport dead)', () => {
@@ -157,6 +196,7 @@ describe('zombie registration (registered but transport dead)', () => {
     const connectSpy = jest.spyOn(client as any, '_connectIfNeeded').mockReturnValue(new Promise(() => {}));
 
     client.register();
+    await flushMicrotasks();
 
     expect(client.registerer).toBeNull(); // stale registerer dropped
     expect(connectSpy).toHaveBeenCalled(); // re-registration flow engaged
@@ -272,6 +312,8 @@ describe('unregister', () => {
     await promise;
 
     expect(registerer.stateChange.addListener).toHaveBeenCalledTimes(1);
-    expect(registerer.stateChange.removeListener).toHaveBeenCalledWith(listeners[0]);
+    // _cleanupRegister() removes every listener, including the one added above
+    expect(registerer.stateChange.removeAllListeners).toHaveBeenCalled();
+    expect(client.registerer).toBeNull();
   });
 });

--- a/src/__tests__/web-rtc-client-multi-client.test.ts
+++ b/src/__tests__/web-rtc-client-multi-client.test.ts
@@ -13,6 +13,10 @@ jest.mock('sip.js/lib/api/user-agent', () => ({
 
     stop = jest.fn(() => Promise.resolve());
 
+    isConnected = jest.fn(() => true);
+
+    onTransportMessage = jest.fn();
+
     transport = { disconnect: jest.fn(() => Promise.resolve()) };
 
     stateChange = { removeAllListeners: jest.fn() };
@@ -88,6 +92,52 @@ describe('live client counter', () => {
     await clientB.close();
 
     expect(getLiveClientCount()).toBe(before);
+  });
+});
+
+describe('zombie registration (registered but transport dead)', () => {
+  const flushMicrotasks = async () => {
+    await Promise.resolve();
+    await Promise.resolve();
+  };
+
+  const makeClient = async () => {
+    const client = new WebRTCClient({} as any, undefined, undefined);
+    await flushMicrotasks(); // let the constructor create its UserAgent
+    return client;
+  };
+
+  it('re-registers when isRegistered() is true but the transport is not connected', async () => {
+    const client = await makeClient();
+    (client.userAgent as any).isConnected.mockReturnValue(false);
+    client.registerer = { state: RegistererState.Registered, stateChange: { removeAllListeners: jest.fn() } } as any;
+    const connectSpy = jest.spyOn(client as any, '_connectIfNeeded').mockReturnValue(new Promise(() => {}));
+
+    client.register();
+
+    expect(client.registerer).toBeNull(); // stale registerer dropped
+    expect(connectSpy).toHaveBeenCalled(); // re-registration flow engaged
+  });
+
+  it('does not re-register when registered and the transport is connected', async () => {
+    const client = await makeClient();
+    (client.userAgent as any).isConnected.mockReturnValue(true);
+    client.registerer = { state: RegistererState.Registered, stateChange: { removeAllListeners: jest.fn() } } as any;
+    const connectSpy = jest.spyOn(client as any, '_connectIfNeeded').mockReturnValue(new Promise(() => {}));
+
+    await client.register();
+
+    expect(connectSpy).not.toHaveBeenCalled();
+  });
+
+  it('tracks the last inbound transport message timestamp', async () => {
+    const client = await makeClient();
+
+    expect(client.getLastTransportMessageAt()).toBeNull();
+
+    (client.userAgent as any).transport.onMessage('SIP/2.0 200 OK\r\n\r\n');
+
+    expect(client.getLastTransportMessageAt()).toBeGreaterThan(0);
   });
 });
 

--- a/src/domain/Phone/WebRTCPhone.ts
+++ b/src/domain/Phone/WebRTCPhone.ts
@@ -1410,6 +1410,10 @@ export default class WebRTCPhone extends Emitter implements Phone {
     return Boolean(this.client?.isConnected());
   }
 
+  isTransportSuspect(): boolean {
+    return this.client ? this.client.isTransportSuspect() : false;
+  }
+
   getLastTransportMessageAt(): number | null {
     return this.client?.getLastTransportMessageAt() ?? null;
   }

--- a/src/domain/Phone/WebRTCPhone.ts
+++ b/src/domain/Phone/WebRTCPhone.ts
@@ -1411,7 +1411,8 @@ export default class WebRTCPhone extends Emitter implements Phone {
   }
 
   isTransportSuspect(): boolean {
-    return this.client ? this.client.isTransportSuspect() : false;
+    // No client means nothing is connected — the most suspect state of all.
+    return this.client ? this.client.isTransportSuspect() : true;
   }
 
   getLastTransportMessageAt(): number | null {

--- a/src/domain/Phone/WebRTCPhone.ts
+++ b/src/domain/Phone/WebRTCPhone.ts
@@ -1406,6 +1406,14 @@ export default class WebRTCPhone extends Emitter implements Phone {
     return this.client && this.client.isRegistered();
   }
 
+  isConnected(): boolean {
+    return Boolean(this.client?.isConnected());
+  }
+
+  getLastTransportMessageAt(): number | null {
+    return this.client?.getLastTransportMessageAt() ?? null;
+  }
+
   enableRinging(): Promise<void> | void {
     logger.info('WebRTC enable ringing');
     this.ringingEnabled = true;

--- a/src/domain/types.ts
+++ b/src/domain/types.ts
@@ -244,7 +244,9 @@ export type WebRtcConfig = {
   heartbeatDelay?: number;
   heartbeatTimeout?: number;
   maxHeartbeats?: number;
-  // Consider a connected-but-silent transport dead after this delay (half-open socket detection).
+  // Consider a connected-but-silent transport dead after this delay (half-open socket
+  // detection). Must be comfortably larger than the server's OPTIONS qualify interval,
+  // otherwise a healthy idle socket gets force-reconnected on every register().
   transportSilenceThresholdMs?: number;
   skipRegister?: boolean;
   userUuid?: string,

--- a/src/domain/types.ts
+++ b/src/domain/types.ts
@@ -244,6 +244,8 @@ export type WebRtcConfig = {
   heartbeatDelay?: number;
   heartbeatTimeout?: number;
   maxHeartbeats?: number;
+  // Consider a connected-but-silent transport dead after this delay (half-open socket detection).
+  transportSilenceThresholdMs?: number;
   skipRegister?: boolean;
   userUuid?: string,
   uaConfigOverrides?: UserAgentConfigOverrides,

--- a/src/simple/Phone.ts
+++ b/src/simple/Phone.ts
@@ -159,15 +159,15 @@ export class Phone extends Emitter {
 
     options.userUuid = session.uuid || '';
 
-    this.connectWithCredentials(server, this.sipLine, session.displayName(), options);
+    return this.connectWithCredentials(server, this.sipLine, session.displayName(), options);
   }
 
-  connectWithCredentials(
+  async connectWithCredentials(
     server: string,
     sipLine: SipLine,
     displayName: string,
     rawOptions: Partial<WebRtcConfig> = {},
-  ): void {
+  ): Promise<void> {
     if (this.phone) {
       // Already connected
       return;
@@ -175,11 +175,13 @@ export class Phone extends Emitter {
 
     if (this.client) {
       // A client without phone remains when a consumer resets `phone` to force a new
-      // connection; close it so two UserAgents don't register the same line.
+      // connection; await the close so two UserAgents never hold the line at once.
       logger.warn('connectWithCredentials: closing previous client before creating a new one');
-      this.client.close().catch((error: any) => {
+      try {
+        await this.client.close();
+      } catch (error: any) {
         logger.error('connectWithCredentials: error while closing previous client', { message: error?.message });
-      });
+      }
     }
 
     const [host, port = 443] = server.split(':');

--- a/src/simple/Phone.ts
+++ b/src/simple/Phone.ts
@@ -178,7 +178,8 @@ export class Phone extends Emitter {
     // Single-flight: closing the previous client below suspends across an await, and two
     // concurrent calls would each build a client — leaving one orphaned alive.
     if (this.connectInFlight) {
-      logger.info('connectWithCredentials: connection already in progress, reusing it');
+      // This call's arguments are discarded in favor of the in-flight connection's.
+      logger.info('connectWithCredentials: connection already in progress, reusing it and ignoring this call\'s arguments', { server, sipLineId: sipLine?.id });
       return this.connectInFlight;
     }
 

--- a/src/simple/Phone.ts
+++ b/src/simple/Phone.ts
@@ -231,11 +231,14 @@ export class Phone extends Emitter {
   async reset(): Promise<void> {
     logger.info('phone reset', { phone: !!this.phone, client: !!this.client });
 
-    if (this.phone) {
-      await this.phone.close().catch((error: any) => {
-        logger.error('reset: error while closing phone', { message: error?.message });
-      });
-    } else if (this.client) {
+    // disconnect() hangs up any active call before closing the phone.
+    await this.disconnect().catch((error: any) => {
+      logger.error('reset: error while disconnecting phone', { message: error?.message });
+    });
+
+    if (this.client) {
+      // Best-effort close of a client the phone close didn't reach (or that failed):
+      // dropping the reference without closing would leave a registered UA behind.
       await this.client.close().catch((error: any) => {
         logger.error('reset: error while closing client', { message: error?.message });
       });

--- a/src/simple/Phone.ts
+++ b/src/simple/Phone.ts
@@ -23,6 +23,8 @@ export class Phone extends Emitter {
 
   phone: WebRTCPhone | null | undefined;
 
+  connectInFlight: Promise<void> | null | undefined;
+
   session: Session;
 
   sipLine: SipLine | null | undefined;
@@ -173,6 +175,25 @@ export class Phone extends Emitter {
       return;
     }
 
+    // Single-flight: closing the previous client below suspends across an await, and two
+    // concurrent calls would each build a client — leaving one orphaned alive.
+    if (this.connectInFlight) {
+      logger.info('connectWithCredentials: connection already in progress, reusing it');
+      return this.connectInFlight;
+    }
+
+    this.connectInFlight = this._connectWithCredentials(server, sipLine, displayName, rawOptions).finally(() => {
+      this.connectInFlight = null;
+    });
+    return this.connectInFlight;
+  }
+
+  private async _connectWithCredentials(
+    server: string,
+    sipLine: SipLine,
+    displayName: string,
+    rawOptions: Partial<WebRtcConfig> = {},
+  ): Promise<void> {
     if (this.client) {
       // A client without phone remains when a consumer resets `phone` to force a new
       // connection; await the close so two UserAgents never hold the line at once.
@@ -181,6 +202,12 @@ export class Phone extends Emitter {
         await this.client.close();
       } catch (error: any) {
         logger.error('connectWithCredentials: error while closing previous client', { message: error?.message });
+      }
+
+      if (this.phone) {
+        // Another path connected while we were closing — keep its phone.
+        logger.info('connectWithCredentials: phone connected while closing previous client, keeping it');
+        return;
       }
     }
 

--- a/src/simple/Phone.ts
+++ b/src/simple/Phone.ts
@@ -173,6 +173,15 @@ export class Phone extends Emitter {
       return;
     }
 
+    if (this.client) {
+      // A client without phone remains when a consumer resets `phone` to force a new
+      // connection; close it so two UserAgents don't register the same line.
+      logger.warn('connectWithCredentials: closing previous client before creating a new one');
+      this.client.close().catch((error: any) => {
+        logger.error('connectWithCredentials: error while closing previous client', { message: error?.message });
+      });
+    }
+
     const [host, port = 443] = server.split(':');
     const options = rawOptions;
     options.media = options.media || {

--- a/src/simple/Phone.ts
+++ b/src/simple/Phone.ts
@@ -226,6 +226,25 @@ export class Phone extends Emitter {
     this.phone = null;
   }
 
+  // Fully tear down the current connection so the next connect() starts fresh,
+  // without consumers having to mutate `phone`/`client` directly.
+  async reset(): Promise<void> {
+    logger.info('phone reset', { phone: !!this.phone, client: !!this.client });
+
+    if (this.phone) {
+      await this.phone.close().catch((error: any) => {
+        logger.error('reset: error while closing phone', { message: error?.message });
+      });
+    } else if (this.client) {
+      await this.client.close().catch((error: any) => {
+        logger.error('reset: error while closing client', { message: error?.message });
+      });
+    }
+
+    this.phone = null;
+    this.client = null as any;
+  }
+
   // If audioOnly is set to true, all video stream will be deactivated, even remotes ones.
   async call(extension: string, withCamera = false, rawSipLine: SipLine | null | undefined = null, audioOnly = false, conference = false): Promise<CallSession | null | undefined> {
     if (!this.phone) {

--- a/src/simple/__tests__/Phone.test.ts
+++ b/src/simple/__tests__/Phone.test.ts
@@ -1,0 +1,50 @@
+import type SipLine from '../../domain/SipLine';
+import { Phone as PhoneClass } from '../Phone';
+
+jest.mock('../../web-rtc-client', () => ({
+  __esModule: true,
+  default: jest.fn().mockImplementation(() => ({
+    on: jest.fn(),
+    close: jest.fn(() => Promise.resolve()),
+  })),
+  events: [],
+  transportEvents: [],
+}));
+
+jest.mock('../../domain/Phone/WebRTCPhone', () => ({
+  __esModule: true,
+  default: jest.fn().mockImplementation(() => ({
+    on: jest.fn(),
+  })),
+  MESSAGE_TYPE_CHAT: 'message/TYPE_CHAT',
+  MESSAGE_TYPE_SIGNAL: 'message/TYPE_SIGNAL',
+}));
+
+const sipLine = { username: 'user', secret: 'secret' } as SipLine;
+
+describe('simple/Phone', () => {
+  describe('connectWithCredentials', () => {
+    it('does not create a second client while phone exists', () => {
+      const phone = new PhoneClass();
+      phone.connectWithCredentials('host:443', sipLine, 'name', {});
+      const firstClient = phone.client;
+
+      phone.connectWithCredentials('host:443', sipLine, 'name', {});
+
+      expect(phone.client).toBe(firstClient);
+    });
+
+    it('closes the previous client before creating a new one', () => {
+      const phone = new PhoneClass();
+      phone.connectWithCredentials('host:443', sipLine, 'name', {});
+      const oldClient = phone.client;
+
+      // Consumers can force a new connection by resetting `phone` (no public reset API yet)
+      phone.phone = null;
+      phone.connectWithCredentials('host:443', sipLine, 'name', {});
+
+      expect(oldClient.close).toHaveBeenCalled();
+      expect(phone.client).not.toBe(oldClient);
+    });
+  });
+});

--- a/src/simple/__tests__/Phone.test.ts
+++ b/src/simple/__tests__/Phone.test.ts
@@ -37,9 +37,32 @@ describe('simple/Phone', () => {
       expect(phone.client).toBe(firstClient);
     });
 
+    it('does not create two clients from concurrent calls in the dangling-client state', async () => {
+      const WebRTCClientMock = jest.requireMock('../../web-rtc-client').default as jest.Mock;
+      const phone = new PhoneClass();
+      await phone.connectWithCredentials('host:443', sipLine, 'name', {});
+
+      // Dangling client: phone reset externally, previous client still alive with a slow close
+      phone.phone = null;
+      let resolveClose: () => void = () => {};
+      (phone.client as any).close = jest.fn(() => new Promise<void>(resolve => {
+        resolveClose = resolve;
+      }));
+      const clientCountBefore = WebRTCClientMock.mock.calls.length;
+
+      const first = phone.connectWithCredentials('host:443', sipLine, 'name', {});
+      const second = phone.connectWithCredentials('host:443', sipLine, 'name', {});
+
+      resolveClose();
+      await Promise.all([first, second]);
+
+      expect(WebRTCClientMock.mock.calls.length - clientCountBefore).toBe(1);
+      expect(phone.phone).toBeTruthy();
+    });
+
     it('closes the previous client before creating a new one', async () => {
       const phone = new PhoneClass();
-      phone.connectWithCredentials('host:443', sipLine, 'name', {});
+      await phone.connectWithCredentials('host:443', sipLine, 'name', {});
       const oldClient = phone.client;
 
       // Consumers can force a new connection by resetting `phone` (no public reset API yet)
@@ -52,7 +75,7 @@ describe('simple/Phone', () => {
 
     it('still connects when closing the previous client rejects', async () => {
       const phone = new PhoneClass();
-      phone.connectWithCredentials('host:443', sipLine, 'name', {});
+      await phone.connectWithCredentials('host:443', sipLine, 'name', {});
       const oldClient: any = phone.client;
       oldClient.close.mockRejectedValue(new Error('close failed'));
 

--- a/src/simple/__tests__/Phone.test.ts
+++ b/src/simple/__tests__/Phone.test.ts
@@ -47,4 +47,31 @@ describe('simple/Phone', () => {
       expect(phone.client).not.toBe(oldClient);
     });
   });
+
+  describe('reset', () => {
+    it('closes the phone and clears phone/client so the next connect starts fresh', async () => {
+      const phone = new PhoneClass();
+      phone.connectWithCredentials('host:443', sipLine, 'name', {});
+      const webRtcPhone: any = phone.phone;
+      webRtcPhone.close = jest.fn(() => Promise.resolve());
+
+      await phone.reset();
+
+      expect(webRtcPhone.close).toHaveBeenCalled();
+      expect(phone.phone).toBeNull();
+      expect(phone.client).toBeNull();
+    });
+
+    it('closes a dangling client when phone is already null', async () => {
+      const phone = new PhoneClass();
+      phone.connectWithCredentials('host:443', sipLine, 'name', {});
+      const { client } = phone;
+      phone.phone = null;
+
+      await phone.reset();
+
+      expect(client.close).toHaveBeenCalled();
+      expect(phone.client).toBeNull();
+    });
+  });
 });

--- a/src/simple/__tests__/Phone.test.ts
+++ b/src/simple/__tests__/Phone.test.ts
@@ -15,6 +15,9 @@ jest.mock('../../domain/Phone/WebRTCPhone', () => ({
   __esModule: true,
   default: jest.fn().mockImplementation(() => ({
     on: jest.fn(),
+    hasAnActiveCall: jest.fn(() => false),
+    hangup: jest.fn(() => Promise.resolve()),
+    close: jest.fn(() => Promise.resolve()),
   })),
   MESSAGE_TYPE_CHAT: 'message/TYPE_CHAT',
   MESSAGE_TYPE_SIGNAL: 'message/TYPE_SIGNAL',
@@ -71,6 +74,42 @@ describe('simple/Phone', () => {
       await phone.reset();
 
       expect(client.close).toHaveBeenCalled();
+      expect(phone.client).toBeNull();
+    });
+
+    it('hangs up an active call before closing', async () => {
+      const phone = new PhoneClass();
+      phone.connectWithCredentials('host:443', sipLine, 'name', {});
+      const webRtcPhone: any = phone.phone;
+      webRtcPhone.hasAnActiveCall.mockReturnValue(true);
+
+      await phone.reset();
+
+      expect(webRtcPhone.hangup).toHaveBeenCalled();
+      expect(webRtcPhone.close).toHaveBeenCalled();
+      expect(phone.phone).toBeNull();
+    });
+
+    it('still force-closes the client and clears references when phone.close() rejects', async () => {
+      const phone = new PhoneClass();
+      phone.connectWithCredentials('host:443', sipLine, 'name', {});
+      const webRtcPhone: any = phone.phone;
+      webRtcPhone.close.mockRejectedValue(new Error('unregister timed out'));
+      const { client } = phone;
+
+      await phone.reset();
+
+      expect(client.close).toHaveBeenCalled(); // otherwise the registered UA is orphaned
+      expect(phone.phone).toBeNull();
+      expect(phone.client).toBeNull();
+    });
+
+    it('is a no-op when nothing is connected', async () => {
+      const phone = new PhoneClass();
+
+      await expect(phone.reset()).resolves.toBeUndefined();
+
+      expect(phone.phone).toBeNull();
       expect(phone.client).toBeNull();
     });
   });

--- a/src/simple/__tests__/Phone.test.ts
+++ b/src/simple/__tests__/Phone.test.ts
@@ -37,17 +37,30 @@ describe('simple/Phone', () => {
       expect(phone.client).toBe(firstClient);
     });
 
-    it('closes the previous client before creating a new one', () => {
+    it('closes the previous client before creating a new one', async () => {
       const phone = new PhoneClass();
       phone.connectWithCredentials('host:443', sipLine, 'name', {});
       const oldClient = phone.client;
 
       // Consumers can force a new connection by resetting `phone` (no public reset API yet)
       phone.phone = null;
-      phone.connectWithCredentials('host:443', sipLine, 'name', {});
+      await phone.connectWithCredentials('host:443', sipLine, 'name', {});
 
       expect(oldClient.close).toHaveBeenCalled();
       expect(phone.client).not.toBe(oldClient);
+    });
+
+    it('still connects when closing the previous client rejects', async () => {
+      const phone = new PhoneClass();
+      phone.connectWithCredentials('host:443', sipLine, 'name', {});
+      const oldClient: any = phone.client;
+      oldClient.close.mockRejectedValue(new Error('close failed'));
+
+      phone.phone = null;
+      await phone.connectWithCredentials('host:443', sipLine, 'name', {});
+
+      expect(phone.client).not.toBe(oldClient);
+      expect(phone.phone).not.toBeNull();
     });
   });
 

--- a/src/simple/room/Room.ts
+++ b/src/simple/room/Room.ts
@@ -1,5 +1,6 @@
 import sdpParser from 'sdp-transform';
 import type { Message } from 'sip.js/lib/api/message';
+import type { OutgoingInviteRequest } from 'sip.js/lib/core';
 import { SessionDescriptionHandler } from 'sip.js/lib/platform/web';
 import type CallSession from '../../domain/CallSession';
 import { PeerConnection, WazoSession } from '../../domain/types';
@@ -429,7 +430,9 @@ class Room extends Emitter {
     Wazo.Phone.sendDTMF(tone, this.callSession as CallSession);
   }
 
-  async sendReinvite(newConstraints: Record<string, any> | null = null) {
+  // Explicit return type: TS2742 — the inferred type references sip.js/lib/core through a
+  // non-portable node_modules path when built from a git dependency (pnpm tmp store).
+  async sendReinvite(newConstraints: Record<string, any> | null = null): Promise<OutgoingInviteRequest | void | undefined> {
     logger.info('send room reinvite', {
       callId: this.callSession ? this.callSession.getId() : null,
       newConstraints,

--- a/src/web-rtc-client.ts
+++ b/src/web-rtc-client.ts
@@ -487,13 +487,13 @@ export default class WebRTCClient extends Emitter {
 
     if (!this.userAgent) {
       logger.info('sdk webrtc registering aborted, no UA can be created');
-      return Promise.resolve();
+      return;
     }
 
     if (this.isRegistered()) {
       if (!this.isTransportSuspect()) {
         logger.info('sdk webrtc registering aborted, already registered');
-        return Promise.resolve();
+        return;
       }
 
       // Zombie registration: the registerer still says Registered but the transport is
@@ -517,7 +517,7 @@ export default class WebRTCClient extends Emitter {
     // @ts-ignore: private
     if (this.connectionPromise || this.registerer?.waiting) {
       logger.info('sdk webrtc registering aborted due to a registration in progress.', { clientId: this.clientId });
-      return Promise.resolve();
+      return;
     }
 
     const registerOptions = this._isWeb() ? {} : {

--- a/src/web-rtc-client.ts
+++ b/src/web-rtc-client.ts
@@ -404,6 +404,30 @@ export default class WebRTCClient extends Emitter {
     return this.lastTransportMessageAt;
   }
 
+  // A transport is suspect when it is disconnected, or when it looks connected but has
+  // been silent longer than `transportSilenceThresholdMs` (half-open socket: TCP died
+  // without a close frame, e.g. during an app freeze). Registered contacts receive
+  // periodic OPTIONS qualify traffic from the server, so a silent socket is a dead one.
+  // Opt-in: without the config threshold only the disconnected state counts.
+  isTransportSuspect(): boolean {
+    if (!this.isConnected()) {
+      return true;
+    }
+
+    // Active sessions exchange SIP/RTP traffic — the socket is alive.
+    if (Object.keys(this.sipSessions).length > 0) {
+      return false;
+    }
+
+    const threshold = this.config.transportSilenceThresholdMs;
+
+    if (!threshold || !this.lastTransportMessageAt) {
+      return false;
+    }
+
+    return Date.now() - this.lastTransportMessageAt > threshold;
+  }
+
   onConnect() {
     logger.info('sdk webrtc connected', { method: 'delegate.onConnect', clientId: this.clientId });
     this.eventEmitter.emit(CONNECTED);
@@ -467,17 +491,27 @@ export default class WebRTCClient extends Emitter {
     }
 
     if (this.isRegistered()) {
-      if (this.isConnected()) {
+      if (!this.isTransportSuspect()) {
         logger.info('sdk webrtc registering aborted, already registered');
         return Promise.resolve();
       }
 
       // Zombie registration: the registerer still says Registered but the transport is
-      // dead (e.g. WebSocket died while the app was frozen). Drop the stale registerer
-      // and continue — _connectIfNeeded() below reconnects the transport before the
-      // new REGISTER.
-      logger.warn('sdk webrtc registered but transport not connected, re-registering', { clientId: this.clientId });
+      // dead or half-open (e.g. WebSocket died while the app was frozen). Drop the stale
+      // registerer and continue — _connectIfNeeded() below reconnects the transport
+      // before the new REGISTER.
+      logger.warn('sdk webrtc registered but transport suspect, re-registering', {
+        clientId: this.clientId,
+        connected: this.isConnected(),
+        lastTransportMessageAt: this.lastTransportMessageAt,
+      });
       this._cleanupRegister();
+
+      if (this.isConnected()) {
+        // Half-open socket: force-close it so _connectIfNeeded() reconnects instead of
+        // trusting the dead socket.
+        await this._disconnectTransport(true);
+      }
     }
 
     // @ts-ignore: private

--- a/src/web-rtc-client.ts
+++ b/src/web-rtc-client.ts
@@ -104,8 +104,15 @@ const MAX_REGISTER_TRIES = 5;
 // setting a 24hr timeout and letting the backend define the actual value
 const NO_ANSWER_TIMEOUT = 60 * 60 * 24; // in seconds
 
+// Observability only: more than one alive client means concurrent UAs can register
+// the same SIP line (expected transiently during connectivity checks).
+let liveClientCount = 0;
+export const getLiveClientCount = (): number => liveClientCount;
+
 export default class WebRTCClient extends Emitter {
   clientId: number;
+
+  _countedAsLive: boolean;
 
   config: WebRtcConfig;
 
@@ -228,6 +235,13 @@ export default class WebRTCClient extends Emitter {
     // For debug purpose
     this.clientId = Math.ceil(Math.random() * 1000);
     logger.info('sdk webrtc constructor', { clientId: this.clientId });
+
+    liveClientCount += 1;
+    this._countedAsLive = true;
+
+    if (liveClientCount > 1) {
+      logger.warn('sdk webrtc multiple clients alive', { liveClientCount, clientId: this.clientId });
+    }
 
     this.uaConfigOverrides = uaConfigOverrides;
     this.config = config;
@@ -841,6 +855,11 @@ export default class WebRTCClient extends Emitter {
       force,
     });
     this.forceClosed = force;
+
+    if (this._countedAsLive) {
+      this._countedAsLive = false;
+      liveClientCount = Math.max(0, liveClientCount - 1);
+    }
 
     this._cleanupMedia();
 

--- a/src/web-rtc-client.ts
+++ b/src/web-rtc-client.ts
@@ -246,7 +246,8 @@ export default class WebRTCClient extends Emitter {
     this.lastTransportMessageAt = null;
 
     if (liveClientCount > 1) {
-      logger.warn('sdk webrtc multiple clients alive', { liveClientCount, clientId: this.clientId });
+      // info, not warn: connectivity checks legitimately create a transient second client.
+      logger.info('sdk webrtc multiple clients alive', { liveClientCount, clientId: this.clientId });
     }
 
     this.uaConfigOverrides = uaConfigOverrides;
@@ -272,6 +273,11 @@ export default class WebRTCClient extends Emitter {
       // With a session, the fetched credentials (authorizationUser/password/uri) differ
       // from what a racing register() used — recreate so REGISTER can authenticate.
       // createUserAgent() stops any previous UA, so nothing leaks.
+      if (this.registerer) {
+        // A racing register() bound the registerer to the UA being replaced; drop it so
+        // it doesn't linger on a stopped UA — the register retry recreates it.
+        this._cleanupRegister();
+      }
       this.userAgent = this.createUserAgent(uaConfigOverrides);
     });
 
@@ -473,6 +479,43 @@ export default class WebRTCClient extends Emitter {
     }
   }
 
+  // Returns true when the current registration sits on a healthy transport. Otherwise
+  // heals the zombie registration — the registerer still says Registered but the
+  // transport is dead or half-open (e.g. WebSocket died while the app was frozen):
+  // drops the stale registerer so register() can proceed, _connectIfNeeded() then
+  // reconnects the transport before the new REGISTER.
+  async _isRegistrationHealthy(): Promise<boolean> {
+    if (!this.isTransportSuspect()) {
+      return true;
+    }
+
+    logger.warn('sdk webrtc registered but transport suspect, re-registering', {
+      clientId: this.clientId,
+      connected: this.isConnected(),
+      lastTransportMessageAt: this.lastTransportMessageAt,
+    });
+    this._cleanupRegister();
+
+    if (this.isConnected()) {
+      // Half-open socket: force-close it AND transition the transport state ourselves.
+      // sip.js keeps reporting Connected until the WS close event fires (up to ~30s on a
+      // dead TCP), so _connectIfNeeded() would short-circuit and send the REGISTER into
+      // the dying socket. connectionPromise guards concurrent register() calls while we
+      // await the disconnect.
+      this.connectionPromise = this._disconnectTransport(true);
+      await this.connectionPromise;
+      this.connectionPromise = null;
+
+      const transport = this.userAgent?.transport as WazoTransport;
+
+      if (transport && transport.state !== TransportState.Disconnected) {
+        transport.transitionState(TransportState.Disconnected);
+      }
+    }
+
+    return false;
+  }
+
   async register(tries = 0): Promise<void> {
     const logInfo = {
       clientId: this.clientId,
@@ -487,6 +530,12 @@ export default class WebRTCClient extends Emitter {
     };
     this.forceClosed = false;
     this._closed = false;
+
+    if (!this._countedAsLive) {
+      // A close()d client revived by register() counts as live again.
+      this._countedAsLive = true;
+      liveClientCount += 1;
+    }
 
     if (this.skipRegister) {
       logger.info('sdk webrtc skip register...', logInfo);
@@ -505,39 +554,9 @@ export default class WebRTCClient extends Emitter {
       return;
     }
 
-    if (this.isRegistered()) {
-      if (!this.isTransportSuspect()) {
-        logger.info('sdk webrtc registering aborted, already registered');
-        return;
-      }
-
-      // Zombie registration: the registerer still says Registered but the transport is
-      // dead or half-open (e.g. WebSocket died while the app was frozen). Drop the stale
-      // registerer and continue — _connectIfNeeded() below reconnects the transport
-      // before the new REGISTER.
-      logger.warn('sdk webrtc registered but transport suspect, re-registering', {
-        clientId: this.clientId,
-        connected: this.isConnected(),
-        lastTransportMessageAt: this.lastTransportMessageAt,
-      });
-      this._cleanupRegister();
-
-      if (this.isConnected()) {
-        // Half-open socket: force-close it AND transition the transport state ourselves.
-        // sip.js keeps reporting Connected until the WS close event fires (up to ~30s on a
-        // dead TCP), so _connectIfNeeded() would short-circuit and send the REGISTER into
-        // the dying socket. connectionPromise guards concurrent register() calls while we
-        // await the disconnect.
-        this.connectionPromise = this._disconnectTransport(true);
-        await this.connectionPromise;
-        this.connectionPromise = null;
-
-        const transport = this.userAgent.transport as WazoTransport;
-
-        if (transport && transport.state !== TransportState.Disconnected) {
-          transport.transitionState(TransportState.Disconnected);
-        }
-      }
+    if (this.isRegistered() && await this._isRegistrationHealthy()) {
+      logger.info('sdk webrtc registering aborted, already registered');
+      return;
     }
 
     // @ts-ignore: private
@@ -672,9 +691,7 @@ export default class WebRTCClient extends Emitter {
         const onRegisterStateChange = (state: string) => {
           if (state === RegistererState.Unregistered) {
             logger.info('sdk webrtc unregistered', { clientId: this.clientId });
-            if (this.registerer) {
-              this.registerer.stateChange.removeListener(onRegisterStateChange);
-            }
+            // _cleanupRegister() removes all stateChange listeners, including this one.
             this._cleanupRegister();
 
             resolve();

--- a/src/web-rtc-client.ts
+++ b/src/web-rtc-client.ts
@@ -114,6 +114,8 @@ export default class WebRTCClient extends Emitter {
 
   _countedAsLive: boolean;
 
+  _closed: boolean;
+
   lastTransportMessageAt: number | null;
 
   config: WebRtcConfig;
@@ -240,6 +242,7 @@ export default class WebRTCClient extends Emitter {
 
     liveClientCount += 1;
     this._countedAsLive = true;
+    this._closed = false;
     this.lastTransportMessageAt = null;
 
     if (liveClientCount > 1) {
@@ -253,13 +256,22 @@ export default class WebRTCClient extends Emitter {
     this._buildConfig(config, session).then((newConfig: WebRtcConfig) => {
       this.config = newConfig;
 
+      if (this._closed) {
+        // close() ran while _buildConfig was in flight; don't start a UA on a closed client.
+        logger.info('sdk webrtc constructor, client closed during config build, skipping UA creation', { clientId: this.clientId });
+        return;
+      }
+
       // register() may have created the userAgent while _buildConfig was in flight;
       // creating another one here would leak the first UA and its transport.
-      if (this.userAgent) {
+      if (this.userAgent && !session) {
         logger.info('sdk webrtc constructor, userAgent already created, skipping', { clientId: this.clientId });
         return;
       }
 
+      // With a session, the fetched credentials (authorizationUser/password/uri) differ
+      // from what a racing register() used — recreate so REGISTER can authenticate.
+      // createUserAgent() stops any previous UA, so nothing leaks.
       this.userAgent = this.createUserAgent(uaConfigOverrides);
     });
 
@@ -325,6 +337,8 @@ export default class WebRTCClient extends Emitter {
   }
 
   createUserAgent(uaConfigOverrides?: UserAgentConfigOverrides): UserAgent {
+    this.lastTransportMessageAt = null;
+
     if (this.userAgent) {
       logger.warn('sdk webrtc, stopping existing UA before creating a new one', { clientId: this.clientId });
       this.userAgent.stop().catch((error: any) => {
@@ -472,6 +486,7 @@ export default class WebRTCClient extends Emitter {
       skipRegister: this.skipRegister,
     };
     this.forceClosed = false;
+    this._closed = false;
 
     if (this.skipRegister) {
       logger.info('sdk webrtc skip register...', logInfo);
@@ -508,9 +523,20 @@ export default class WebRTCClient extends Emitter {
       this._cleanupRegister();
 
       if (this.isConnected()) {
-        // Half-open socket: force-close it so _connectIfNeeded() reconnects instead of
-        // trusting the dead socket.
-        await this._disconnectTransport(true);
+        // Half-open socket: force-close it AND transition the transport state ourselves.
+        // sip.js keeps reporting Connected until the WS close event fires (up to ~30s on a
+        // dead TCP), so _connectIfNeeded() would short-circuit and send the REGISTER into
+        // the dying socket. connectionPromise guards concurrent register() calls while we
+        // await the disconnect.
+        this.connectionPromise = this._disconnectTransport(true);
+        await this.connectionPromise;
+        this.connectionPromise = null;
+
+        const transport = this.userAgent.transport as WazoTransport;
+
+        if (transport && transport.state !== TransportState.Disconnected) {
+          transport.transitionState(TransportState.Disconnected);
+        }
       }
     }
 
@@ -913,6 +939,7 @@ export default class WebRTCClient extends Emitter {
       force,
     });
     this.forceClosed = force;
+    this._closed = true;
 
     if (this._countedAsLive) {
       this._countedAsLive = false;

--- a/src/web-rtc-client.ts
+++ b/src/web-rtc-client.ts
@@ -114,6 +114,8 @@ export default class WebRTCClient extends Emitter {
 
   _countedAsLive: boolean;
 
+  lastTransportMessageAt: number | null;
+
   config: WebRtcConfig;
 
   uaConfigOverrides?: UserAgentConfigOverrides;
@@ -238,6 +240,7 @@ export default class WebRTCClient extends Emitter {
 
     liveClientCount += 1;
     this._countedAsLive = true;
+    this.lastTransportMessageAt = null;
 
     if (liveClientCount > 1) {
       logger.warn('sdk webrtc multiple clients alive', { liveClientCount, clientId: this.clientId });
@@ -364,6 +367,9 @@ export default class WebRTCClient extends Emitter {
     }
 
     ua.transport.onMessage = (rawMessage: string) => {
+      // Any inbound traffic (responses, OPTIONS qualify…) proves the transport is alive;
+      // consumers use this to detect half-open sockets that still report Connected.
+      this.lastTransportMessageAt = Date.now();
       const message = Parser.parseMessage(rawMessage, (ua.transport as any).logger);
       // We have to re-sent the message to the UA ...
       // @ts-ignore: private
@@ -392,6 +398,10 @@ export default class WebRTCClient extends Emitter {
 
   isRegistered(): boolean {
     return Boolean(this.registerer && this.registerer.state === RegistererState.Registered);
+  }
+
+  getLastTransportMessageAt(): number | null {
+    return this.lastTransportMessageAt;
   }
 
   onConnect() {
@@ -451,9 +461,23 @@ export default class WebRTCClient extends Emitter {
       this.userAgent = this.createUserAgent(this.uaConfigOverrides);
     }
 
-    if (!this.userAgent || this.isRegistered()) {
-      logger.info('sdk webrtc registering aborted, already registered or no UA can be created');
+    if (!this.userAgent) {
+      logger.info('sdk webrtc registering aborted, no UA can be created');
       return Promise.resolve();
+    }
+
+    if (this.isRegistered()) {
+      if (this.isConnected()) {
+        logger.info('sdk webrtc registering aborted, already registered');
+        return Promise.resolve();
+      }
+
+      // Zombie registration: the registerer still says Registered but the transport is
+      // dead (e.g. WebSocket died while the app was frozen). Drop the stale registerer
+      // and continue — _connectIfNeeded() below reconnects the transport before the
+      // new REGISTER.
+      logger.warn('sdk webrtc registered but transport not connected, re-registering', { clientId: this.clientId });
+      this._cleanupRegister();
     }
 
     // @ts-ignore: private

--- a/src/web-rtc-client.ts
+++ b/src/web-rtc-client.ts
@@ -575,7 +575,7 @@ export default class WebRTCClient extends Emitter {
           if (state === RegistererState.Unregistered) {
             logger.info('sdk webrtc unregistered', { clientId: this.clientId });
             if (this.registerer) {
-              this.registerer.stateChange.addListener(onRegisterStateChange);
+              this.registerer.stateChange.removeListener(onRegisterStateChange);
             }
             this._cleanupRegister();
 

--- a/src/web-rtc-client.ts
+++ b/src/web-rtc-client.ts
@@ -235,6 +235,14 @@ export default class WebRTCClient extends Emitter {
 
     this._buildConfig(config, session).then((newConfig: WebRtcConfig) => {
       this.config = newConfig;
+
+      // register() may have created the userAgent while _buildConfig was in flight;
+      // creating another one here would leak the first UA and its transport.
+      if (this.userAgent) {
+        logger.info('sdk webrtc constructor, userAgent already created, skipping', { clientId: this.clientId });
+        return;
+      }
+
       this.userAgent = this.createUserAgent(uaConfigOverrides);
     });
 
@@ -300,6 +308,14 @@ export default class WebRTCClient extends Emitter {
   }
 
   createUserAgent(uaConfigOverrides?: UserAgentConfigOverrides): UserAgent {
+    if (this.userAgent) {
+      logger.warn('sdk webrtc, stopping existing UA before creating a new one', { clientId: this.clientId });
+      this.userAgent.stop().catch((error: any) => {
+        logger.error('sdk webrtc, error stopping previous UA', { error: error?.message, clientId: this.clientId });
+      });
+      this.userAgent = null;
+    }
+
     const uaOptions = this._createUaOptions(uaConfigOverrides);
 
     logger.info('sdk webrtc, creating UA', {


### PR DESCRIPTION
## Summary of the changes

- A `register()` call racing the constructor's async `_buildConfig` could end up creating two sip.js UserAgents on the same client: the first one stayed alive with its WebSocket open and registered, competing for INVITEs with the new one. The constructor now skips UA creation when one already exists, and `createUserAgent()` defensively stops any previous UA.
- `Phone.connectWithCredentials()` now closes the previous `client` before creating a new one (a dangling client could survive when `phone` was reset externally).
- Fixed `unregister()` re-adding its stateChange listener instead of removing it.
- Added a live-client counter (`getLiveClientCount()`) that logs a warning when more than one client is alive. Warn only — connectivity checks legitimately create a transient second client.
- Added `Phone.reset()` so consumers can force a fresh connection instead of mutating `Wazo.Phone.phone`/`.client` directly.
- **Zombie registration heal**: a WebSocket dying while the app is frozen leaves the registerer in Registered state, and `register()` early-returned forever — the client could never re-register. `register()` now drops the stale registerer and reconnects when the transport is suspect.
- **Half-open socket detection** (opt-in via `transportSilenceThresholdMs`): a socket can look Connected while its TCP is dead. Registered contacts receive periodic OPTIONS qualify traffic, so the client now tracks `lastTransportMessageAt`; when silent past the threshold, `register()` force-closes and reconnects the transport. Skipped while sip sessions are active. `isTransportSuspect()`/`isConnected()`/`getLastTransportMessageAt()` are exposed on `WebRTCPhone`.

## How to test

- `pnpm jest src/__tests__/web-rtc-client-multi-client.test.ts src/simple/__tests__/Phone.test.ts` — covers the constructor/register race, double-connect, unregister listener, `reset()`, zombie re-register and half-open detection.
- Full suite: `pnpm test`.