### PR TITLE
ITEM-450 inject-call-id-for-outgoing

### DIFF
--- a/src/domain/Phone/WebRTCPhone.ts
+++ b/src/domain/Phone/WebRTCPhone.ts
@@ -1629,7 +1629,6 @@ export default class WebRTCPhone extends Emitter implements Phone {
       const callSession = this._createCallSession(session, null, {
         incoming: false,
         ringing: true,
-        callId: this.getSipSessionId(session),
       });
 
       this.eventEmitter.emit(ON_PROGRESS, callSession, this.audioOutputDeviceId, this.audioOutputVolume);
@@ -1640,7 +1639,6 @@ export default class WebRTCPhone extends Emitter implements Phone {
       const callSession = this._createCallSession(session, null, {
         incoming: false,
         ringing: true,
-        callId: this.getSipSessionId(session),
       });
 
       this.eventEmitter.emit(ON_EARLY_MEDIA, callSession, this.audioOutputDeviceId, this.audioOutputVolume);

--- a/src/domain/Phone/WebRTCPhone.ts
+++ b/src/domain/Phone/WebRTCPhone.ts
@@ -1868,9 +1868,10 @@ export default class WebRTCPhone extends Emitter implements Phone {
     } = sipSession || {};
     const sessionId = this.getSipSessionId(sipSession);
     fromSession = fromSession || this.callSessions[sessionId];
-    // wazo-calld exposes the channel id of our own leg in the INVITE, so the
-    // Wazo call id is known without having to fetch GET /users/me/calls.
-    const headerCallId = sipSession?.request?.getHeader?.('X-Wazo-Call-ID');
+    // The Wazo platform >=26.08 exposes the channel id of our own leg in X-Wazo-Call-ID
+    // incoming calls carry it in the INVITE (request header), outgoing calls
+    // receive it in the INVITE responses (stashed by web-rtc-client).
+    const headerCallId = (sipSession as any)?.wazoCallId || sipSession?.request?.getHeader?.('X-Wazo-Call-ID');
     const callSession = new CallSession({
       callId: fromSession?.callId || headerCallId || '',
       sipCallId: sessionId,

--- a/src/domain/Phone/__tests__/WebRTCPhone.test.ts
+++ b/src/domain/Phone/__tests__/WebRTCPhone.test.ts
@@ -154,6 +154,34 @@ describe('WebRTCPhone._createCallSession callId', () => {
 
     expect(cs.callId).toBe('');
   });
+
+  it('maps the wazoCallId stashed from INVITE responses (outgoing call) to callId', () => {
+    const sipSession = { id: 'session-1', wazoCallId: '1719843012.43' } as any;
+    const phone = createPhone(createCreatableMockClient({ 'session-1': sipSession }));
+
+    const cs = phone._createCallSession(sipSession);
+
+    expect(cs.callId).toBe('1719843012.43');
+  });
+
+  it('prefers the stashed wazoCallId over the request header', () => {
+    const sipSession = { id: 'session-1', wazoCallId: '1719843012.43', request: requestWithHeader('1719843012.42') } as any;
+    const phone = createPhone(createCreatableMockClient({ 'session-1': sipSession }));
+
+    const cs = phone._createCallSession(sipSession);
+
+    expect(cs.callId).toBe('1719843012.43');
+  });
+
+  it('keeps the callId of the previous call session over the stashed wazoCallId', () => {
+    const sipSession = { id: 'session-1', wazoCallId: '1719843012.43' } as any;
+    const phone = createPhone(createCreatableMockClient({ 'session-1': sipSession }));
+    const fromSession = new CallSession({ callId: 'existing-id', sipCallId: 'session-1' } as any);
+
+    const cs = phone._createCallSession(sipSession, fromSession);
+
+    expect(cs.callId).toBe('existing-id');
+  });
 });
 
 describe('WebRTCPhone.setCallSessionCallId', () => {

--- a/src/simple/Phone.ts
+++ b/src/simple/Phone.ts
@@ -242,9 +242,10 @@ export class Phone extends Emitter {
 
     this._transferEvents();
 
-    // The `call_created` event carries the Wazo call id of our own leg, which
-    // outgoing calls can't learn from SIP; with it set, REST actions don't
-    // require fetching GET /users/me/calls.
+    // The `call_created` event carries the Wazo call id of our own leg; with
+    // it set, REST actions don't require fetching GET /users/me/calls. Kept as
+    // a fallback for engines that don't expose the call id over SIP in the
+    // X-Wazo-Call-ID header (Wazo platform < 26.08).
     Wazo.Websocket.on(Wazo.Websocket.CALL_CREATED, this._onCallCreated);
   }
 

--- a/src/web-rtc-client.ts
+++ b/src/web-rtc-client.ts
@@ -774,15 +774,28 @@ export default class WebRTCClient extends Emitter {
       this.conferences[this.getSipSessionId(session)] = true;
     }
 
+    // Asterisk (res_pjsip_wazo_call_id) exposes the Wazo call id of our own
+    // leg in INVITE responses; stash it on the sip session so call sessions
+    // can be built without fetching GET /users/me/calls.
+    const stashWazoCallId = (response: IncomingResponse) => {
+      const wazoCallId = response.message.getHeader('X-Wazo-Call-ID');
+
+      if (wazoCallId && session && !(session as any).wazoCallId) {
+        (session as any).wazoCallId = wazoCallId;
+      }
+    };
+
     const inviteOptions: InviterInviteOptions = {
       requestDelegate: {
         onAccept: (response: IncomingResponse) => {
+          stashWazoCallId(response);
           if ((session?.sessionDescriptionHandler as any)?.peerConnection) {
             (session?.sessionDescriptionHandler as any).peerConnection.sfu = conference;
           }
           this._onAccepted(session as WazoSession, response.session, true);
         },
         onProgress: (payload: IncomingResponse) => {
+          stashWazoCallId(payload);
           this._onProgress(payload.session, payload.message.statusCode === 183);
         },
         onReject: (response: IncomingResponse) => {


### PR DESCRIPTION
- **Set callId on outgoing calls from X-Wazo-Call-ID INVITE responses**


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how outgoing calls are keyed for REST/calld APIs; incorrect ids could break mute/hold/transfer, but behavior is covered by tests and existing call_created fallback remains.
> 
> **Overview**
> Outgoing WebRTC calls now get the Wazo **call id** on `CallSession` as soon as SIP progress/accept responses arrive, so calld REST actions (mute, hold, etc.) can run without waiting on `call_created` or `GET /users/me/calls`.
> 
> **web-rtc-client** reads `X-Wazo-Call-ID` from outgoing INVITE responses (`onProgress` / `onAccept`) and stores it on the SIP session as `wazoCallId`. **WebRTCPhone** `_createCallSession` prefers that value, then the INVITE request header (incoming), then any id already on the session. **ON_PROGRESS** / **ON_EARLY_MEDIA** no longer pass a bogus `callId` derived from the SIP session id.
> 
> Websocket `call_created` handling stays as a fallback for Wazo **&lt; 26.08** when the header is not exposed over SIP. Unit tests cover `wazoCallId` mapping and precedence.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dd952f76005d9f82fb69dc5c4a90ec6d5529789a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->