### PR TITLE
ITEM-450 call-created-hook

### DIFF
--- a/src/domain/Phone/WebRTCPhone.ts
+++ b/src/domain/Phone/WebRTCPhone.ts
@@ -1742,6 +1742,22 @@ export default class WebRTCPhone extends Emitter implements Phone {
     return this.callSessions[sipSessionId];
   }
 
+  // Learn the Wazo call id of our own leg (eg. from a `call_created` bus
+  // event) so REST actions don't require fetching GET /users/me/calls.
+  setCallSessionCallId(sipCallId: string, callId: string): void {
+    const callSession = this.callSessions[sipCallId];
+
+    if (!callSession || callSession.callId) {
+      return;
+    }
+
+    logger.info('setting wazo call id on call session', {
+      sipCallId,
+      callId,
+    });
+    callSession.callId = callId;
+  }
+
   getSipSessionId(sipSession: WazoSession | null | undefined): string {
     if (!sipSession) {
       return '';

--- a/src/domain/Phone/__tests__/WebRTCPhone.test.ts
+++ b/src/domain/Phone/__tests__/WebRTCPhone.test.ts
@@ -156,6 +156,34 @@ describe('WebRTCPhone._createCallSession callId', () => {
   });
 });
 
+describe('WebRTCPhone.setCallSessionCallId', () => {
+  it('sets the callId on the call session matching the sip call id', () => {
+    const phone = createPhone(createCreatableMockClient());
+    const callSession = new CallSession({ sipCallId: 'abcdef' } as any);
+    phone.callSessions.abcdef = callSession;
+
+    phone.setCallSessionCallId('abcdef', '1719843012.42');
+
+    expect(callSession.callId).toBe('1719843012.42');
+  });
+
+  it('does not overwrite an already known callId', () => {
+    const phone = createPhone(createCreatableMockClient());
+    const callSession = new CallSession({ callId: 'existing-id', sipCallId: 'abcdef' } as any);
+    phone.callSessions.abcdef = callSession;
+
+    phone.setCallSessionCallId('abcdef', '1719843012.42');
+
+    expect(callSession.callId).toBe('existing-id');
+  });
+
+  it('ignores unknown sip call ids', () => {
+    const phone = createPhone(createCreatableMockClient());
+
+    expect(() => phone.setCallSessionCallId('unknown', '1719843012.42')).not.toThrow();
+  });
+});
+
 describe('WebRTCPhone._createCallSession assertedIdentity', () => {
   // Shaped like sip.js's `Session.assertedIdentity` (a parsed NameAddrHeader).
   // The URI exposes the user via the public `user` getter and the private

--- a/src/simple/Phone.ts
+++ b/src/simple/Phone.ts
@@ -241,9 +241,16 @@ export class Phone extends Emitter {
     this.phone = new WebRTCPhone(this.client, options.audioDeviceOutput, true, options.audioDeviceRing);
 
     this._transferEvents();
+
+    // The `call_created` event carries the Wazo call id of our own leg, which
+    // outgoing calls can't learn from SIP; with it set, REST actions don't
+    // require fetching GET /users/me/calls.
+    Wazo.Websocket.on(Wazo.Websocket.CALL_CREATED, this._onCallCreated);
   }
 
   async disconnect(): Promise<void> {
+    Wazo.Websocket.off(Wazo.Websocket.CALL_CREATED, this._onCallCreated);
+
     if (this.phone) {
       if (this.phone.hasAnActiveCall()) {
         logger.info('hangup call on disconnect');
@@ -277,6 +284,12 @@ export class Phone extends Emitter {
     this.phone = null;
     this.client = null as any;
   }
+
+  _onCallCreated = ({ data }: { data: Record<string, any> }): void => {
+    if (this.phone && data?.sip_call_id && data?.call_id) {
+      this.phone.setCallSessionCallId(data.sip_call_id, data.call_id);
+    }
+  };
 
   // If audioOnly is set to true, all video stream will be deactivated, even remotes ones.
   async call(extension: string, withCamera = false, rawSipLine: SipLine | null | undefined = null, audioOnly = false, conference = false): Promise<CallSession | null | undefined> {


### PR DESCRIPTION
Why: outgoing calls don't carry X-Wazo-Call-ID in their INVITE, so
their call sessions had no Wazo call id until GET /users/me/calls was
fetched. The call_created websocket event carries both sip_call_id and
call_id, letting the SDK map the Wazo call id onto the matching call
session as soon as the event arrives.

A callId already known on the call session is never overwritten.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches live call identity and websocket lifecycle; wrong mapping could break calld API actions, but guards limit overwrites and scope is narrow.
> 
> **Overview**
> Outgoing WebRTC calls no longer get `X-Wazo-Call-ID` on the INVITE, so `CallSession.callId` stayed empty until something like `GET /users/me/calls` ran—blocking calld REST helpers that need the Wazo id (e.g. mute via API).
> 
> **`WebRTCPhone.setCallSessionCallId`** maps `sip_call_id` → `call_id` on the matching session when `callId` is still unset; an existing id is never overwritten.
> 
> **`Wazo.Phone`** registers for `Wazo.Websocket.CALL_CREATED` after connect and forwards `sip_call_id` / `call_id` into that setter; the listener is removed on `disconnect`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c34e62febe5c1b948f7563a2dfd2502c21b8be4a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->