### PR TITLE
fix(webrtc): stop advertising and re-enabling video on audio-only answered calls

### DIFF
--- a/src/__tests__/web-rtc-client.test.ts
+++ b/src/__tests__/web-rtc-client.test.ts
@@ -542,6 +542,179 @@ describe('changeAudioInputDevice', () => {
   });
 });
 
+describe('reinvite video decision', () => {
+  const spies: jest.SpyInstance[] = [];
+  let mediaConfigSpy: jest.SpyInstance;
+  let sessionWantsToDoVideoSpy: jest.SpyInstance;
+
+  const buildSession = () => ({
+    pendingReinvite: false,
+    sessionDescriptionHandlerModifiersReInvite: [],
+    sessionDescriptionHandlerOptionsReInvite: {},
+    invite: jest.fn().mockResolvedValue(undefined),
+  } as any);
+
+  beforeEach(() => {
+    mediaConfigSpy = jest.spyOn(client, 'getMediaConfiguration');
+    sessionWantsToDoVideoSpy = jest.spyOn(client, 'sessionWantsToDoVideo');
+    spies.push(
+      mediaConfigSpy,
+      sessionWantsToDoVideoSpy,
+      jest.spyOn(client, 'isAudioMuted').mockReturnValue(false),
+      jest.spyOn(client, 'getSipSessionId').mockReturnValue('reinvite-1'),
+    );
+  });
+
+  afterEach(() => {
+    spies.forEach(s => s.mockRestore());
+    spies.length = 0;
+  });
+
+  it('does not request video on a constraint-less reinvite when there is no local video', async () => {
+    // The remote SDP advertises video (incoming video call answered audio-only): following it
+    // would turn the camera on without consent on ICE restart / network change reinvites.
+    spies.push(jest.spyOn(client, 'hasLocalVideo').mockReturnValue(false));
+
+    await client.reinvite(buildSession(), null, false, false, true);
+
+    expect(mediaConfigSpy).toHaveBeenCalledWith(false, false, null);
+    expect(sessionWantsToDoVideoSpy).not.toHaveBeenCalled();
+  });
+
+  it('keeps video on a constraint-less reinvite when local video is active', async () => {
+    spies.push(jest.spyOn(client, 'hasLocalVideo').mockReturnValue(true));
+
+    await client.reinvite(buildSession(), null, false, false, true);
+
+    expect(mediaConfigSpy).toHaveBeenCalledWith(true, false, null);
+  });
+
+  it('follows explicit constraints when provided', async () => {
+    spies.push(jest.spyOn(client, 'hasLocalVideo').mockReturnValue(false));
+    const constraints = { video: true };
+
+    await client.reinvite(buildSession(), constraints, false, false, false);
+
+    expect(mediaConfigSpy).toHaveBeenCalledWith(true, false, constraints);
+  });
+});
+
+describe('remote video detection', () => {
+  const sessionId = 'remote-video-1';
+
+  const setSession = (remoteMediaStream: any, peerConnection: any = {}) => {
+    (client as any).sipSessions[sessionId] = {
+      sessionDescriptionHandler: { remoteMediaStream, peerConnection },
+    };
+  };
+
+  afterEach(() => {
+    delete (client as any).sipSessions[sessionId];
+  });
+
+  describe('hasRemoteVideo', () => {
+    const streamWithTracks = (tracks: any[]) => ({ getTracks: () => tracks });
+
+    it('ignores a live but muted video track (negotiated m-line that never received RTP)', () => {
+      setSession(streamWithTracks([{ kind: 'video', readyState: 'live', muted: true }]));
+
+      expect(client.hasRemoteVideo(sessionId)).toBe(false);
+    });
+
+    it('detects a live unmuted video track', () => {
+      setSession(streamWithTracks([{ kind: 'video', readyState: 'live', muted: false }]));
+
+      expect(client.hasRemoteVideo(sessionId)).toBe(true);
+    });
+
+    it('ignores audio tracks', () => {
+      setSession(streamWithTracks([{ kind: 'audio', readyState: 'live', muted: false }]));
+
+      expect(client.hasRemoteVideo(sessionId)).toBe(false);
+    });
+  });
+
+  describe('updateRemoteStream', () => {
+    const makeRemoteStream = () => {
+      const tracks: any[] = [];
+      return {
+        tracks,
+        getTracks: () => [...tracks],
+        addTrack: (track: any) => tracks.push(track),
+        removeTrack: (track: any) => {
+          const index = tracks.indexOf(track);
+          if (index !== -1) {
+            tracks.splice(index, 1);
+          }
+        },
+      };
+    };
+
+    it('skips receiver tracks whose transceiver is not receiving', () => {
+      const remoteStream = makeRemoteStream();
+      const receivingReceiver = { track: { kind: 'audio' } };
+      const phantomReceiver = { track: { kind: 'video' } };
+      const pc = {
+        getReceivers: () => [receivingReceiver, phantomReceiver],
+        getTransceivers: () => [
+          { receiver: receivingReceiver, currentDirection: 'sendrecv' },
+          // Our video offer was answered `recvonly`: we send, we never receive.
+          { receiver: phantomReceiver, currentDirection: 'sendonly' },
+        ],
+      };
+      setSession(remoteStream, pc);
+
+      client.updateRemoteStream(sessionId);
+
+      expect(remoteStream.tracks).toEqual([receivingReceiver.track]);
+    });
+
+    it('adds receiver tracks for receiving transceivers, using direction before negotiation', () => {
+      const remoteStream = makeRemoteStream();
+      const receiver = { track: { kind: 'video' } };
+      const pc = {
+        getReceivers: () => [receiver],
+        getTransceivers: () => [{ receiver, currentDirection: null, direction: 'recvonly' }],
+      };
+      setSession(remoteStream, pc);
+
+      client.updateRemoteStream(sessionId);
+
+      expect(remoteStream.tracks).toEqual([receiver.track]);
+    });
+
+    it('keeps all receiver tracks when transceivers are not available', () => {
+      const remoteStream = makeRemoteStream();
+      const audioReceiver = { track: { kind: 'audio' } };
+      const videoReceiver = { track: { kind: 'video' } };
+      const pc = {
+        getReceivers: () => [audioReceiver, videoReceiver],
+      };
+      setSession(remoteStream, pc);
+
+      client.updateRemoteStream(sessionId);
+
+      expect(remoteStream.tracks).toEqual([audioReceiver.track, videoReceiver.track]);
+    });
+
+    it('only touches video tracks when allTracks is false', () => {
+      const remoteStream = makeRemoteStream();
+      const existingAudioTrack = { kind: 'audio' };
+      remoteStream.addTrack(existingAudioTrack);
+      const videoReceiver = { track: { kind: 'video' } };
+      const pc = {
+        getReceivers: () => [videoReceiver],
+        getTransceivers: () => [{ receiver: videoReceiver, currentDirection: 'sendrecv' }],
+      };
+      setSession(remoteStream, pc);
+
+      client.updateRemoteStream(sessionId, false);
+
+      expect(remoteStream.tracks).toEqual([existingAudioTrack, videoReceiver.track]);
+    });
+  });
+});
+
 describe('toAssertedIdentity', () => {
   // Shaped like sip.js's parsed P-Asserted-Identity header (a NameAddrHeader).
   const makeIdentity = (user: string | undefined, displayName: string) => ({

--- a/src/lib/WazoSessionDescriptionHandler.ts
+++ b/src/lib/WazoSessionDescriptionHandler.ts
@@ -376,6 +376,7 @@ class WazoSessionDescriptionHandler extends SessionDescriptionHandler {
             ) {
               const {
                 receiver,
+                sender,
               } = transceiver;
 
               if (isConference && audioOnly && receiver.track && receiver.track.kind === 'video') {
@@ -386,15 +387,30 @@ class WazoSessionDescriptionHandler extends SessionDescriptionHandler {
                 return;
               }
 
-              if (transceiver.direction !== 'stopped' && transceiver.direction !== answerDirection) {
+              // A video transceiver without a local track can't send anything: advertising a
+              // sending direction makes the remote peer render a frame-less (frozen/black) video
+              // tile. Cap the answer to its receiving part. Conferences are excluded: the SFU
+              // path negotiates track-less `sendrecv` bundles on purpose, to allow a later
+              // `replaceTrack` upgrade without renegotiation.
+              let transceiverDirection = answerDirection;
+
+              if (!isConference && receiver.track?.kind === 'video' && !sender?.track) {
+                if (answerDirection === 'sendrecv') {
+                  transceiverDirection = 'recvonly';
+                } else if (answerDirection === 'sendonly') {
+                  transceiverDirection = 'inactive';
+                }
+              }
+
+              if (transceiver.direction !== 'stopped' && transceiver.direction !== transceiverDirection) {
                 // eslint-disable-next-line no-param-reassign
-                transceiver.direction = answerDirection;
+                transceiver.direction = transceiverDirection;
               }
 
               // Set unconditionally: track.enabled may be out of sync even when direction didn't change
               if (receiver?.track) {
                 // eslint-disable-next-line no-param-reassign
-                receiver.track.enabled = (answerDirection === 'sendrecv' || answerDirection === 'recvonly');
+                receiver.track.enabled = (transceiverDirection === 'sendrecv' || transceiverDirection === 'recvonly');
               }
             }
           });

--- a/src/lib/__tests__/WazoSessionDescriptionHandler.test.ts
+++ b/src/lib/__tests__/WazoSessionDescriptionHandler.test.ts
@@ -18,10 +18,11 @@ jest.mock('../../service/IssueReporter', () => null);
 
 const makeTrack = (kind = 'audio', enabled = true) => ({ kind, enabled });
 
-const makeTransceiver = (direction: string, trackKind = 'audio', stopped = false) => ({
+const makeTransceiver = (direction: string, trackKind = 'audio', stopped = false, senderTrack: any = null) => ({
   direction,
   stopped,
   receiver: { track: makeTrack(trackKind) },
+  sender: { track: senderTrack },
 });
 
 const makePeerConnection = (signalingState: string, transceivers: any[], sdp?: string) => ({
@@ -446,6 +447,55 @@ describe('WazoSessionDescriptionHandler.updateDirection', () => {
       expect(videoT.receiver.track.enabled).toBe(false);
       expect(audioT.direction).toBe('sendrecv');
       expect(audioT.receiver.track.enabled).toBe(true);
+    });
+
+    it('audio-only answer to a video offer: video transceiver without a local track answers recvonly', async () => {
+      // Alice answers audio-only: her audio transceiver has a local track, her video one doesn't.
+      const audioT = makeTransceiver('sendrecv', 'audio', false, makeTrack('audio'));
+      const videoT = makeTransceiver('sendrecv', 'video');
+      const pc = makePeerConnection('have-remote-offer', [audioT, videoT], 'a=sendrecv\r\n');
+      const handler = createHandler(pc);
+
+      await handler.updateDirection({} as any);
+
+      expect(audioT.direction).toBe('sendrecv');
+      expect(audioT.receiver.track.enabled).toBe(true);
+      // Advertising `sendrecv` here makes the caller render a frame-less video tile.
+      expect(videoT.direction).toBe('recvonly');
+      expect(videoT.receiver.track.enabled).toBe(true);
+    });
+
+    it('video answer to a video offer: video transceiver with a local track answers sendrecv', async () => {
+      const videoT = makeTransceiver('sendrecv', 'video', false, makeTrack('video'));
+      const pc = makePeerConnection('have-remote-offer', [videoT], 'a=sendrecv\r\n');
+      const handler = createHandler(pc);
+
+      await handler.updateDirection({} as any);
+
+      expect(videoT.direction).toBe('sendrecv');
+      expect(videoT.receiver.track.enabled).toBe(true);
+    });
+
+    it('hold on an audio-only answered video call: trackless video transceiver answers inactive', async () => {
+      const videoT = makeTransceiver('sendrecv', 'video');
+      const pc = makePeerConnection('have-remote-offer', [videoT], 'a=sendrecv\r\n');
+      const handler = createHandler(pc);
+
+      await handler.updateDirection({ hold: true } as any);
+
+      expect(videoT.direction).toBe('inactive');
+      expect(videoT.receiver.track.enabled).toBe(false);
+    });
+
+    it('conference answer: trackless video transceiver keeps sendrecv for later replaceTrack upgrade', async () => {
+      const videoT = makeTransceiver('sendrecv', 'video');
+      const pc = makePeerConnection('have-remote-offer', [videoT], 'a=sendrecv\r\n');
+      const handler = createHandler(pc);
+
+      await handler.updateDirection({} as any, true, false);
+
+      expect(videoT.direction).toBe('sendrecv');
+      expect(videoT.receiver.track.enabled).toBe(true);
     });
 
     it('stopped transceiver is skipped', async () => {

--- a/src/web-rtc-client.ts
+++ b/src/web-rtc-client.ts
@@ -1628,7 +1628,11 @@ export default class WebRTCClient extends Emitter {
     }
 
     const wasMuted = this.isAudioMuted(sipSession);
-    const shouldDoVideo = newConstraints ? newConstraints.video : this.sessionWantsToDoVideo(sipSession);
+    // When no constraints are given (automatic reinvites: ICE restart, network change), derive the
+    // video decision from the local state, not from the SDP: `sessionWantsToDoVideo` reflects the
+    // remote offer, which advertises video even when the user answered audio-only — following it
+    // here would silently turn the camera on without consent.
+    const shouldDoVideo = newConstraints ? newConstraints.video : this.hasLocalVideo(this.getSipSessionId(sipSession));
     const shouldDoScreenSharing = newConstraints && newConstraints.screen;
     const desktop = newConstraints && newConstraints.desktop;
     logger.info('Sending reinvite', {
@@ -1770,7 +1774,10 @@ export default class WebRTCClient extends Emitter {
   }
 
   hasRemoteVideo(sessionId: string): boolean {
-    return this.getRemoteTracks(sessionId).some(this._isVideoTrack);
+    // `muted` filters out negotiated receiver tracks that never got RTP: they stay `live`
+    // forever even though no frame will ever arrive (e.g. the peer answered our video offer
+    // without sending video). Use `hasARemoteVideoTrack` for the lax check.
+    return this.getRemoteTracks(sessionId).some(track => this._isVideoTrack(track) && !track.muted);
   }
 
   // Check if we have at least one video track, even muted or not live
@@ -2051,10 +2058,25 @@ export default class WebRTCClient extends Emitter {
     });
 
     if (pc.getReceivers) {
+      // `getReceivers()` returns a receiver for every negotiated m-line, including ones the
+      // remote never sends on (e.g. our video offer answered `recvonly`). Adding those phantom
+      // tracks makes the remote stream claim video that will never produce a frame, so skip
+      // receivers whose transceiver is not in a receiving direction.
+      const transceivers = pc.getTransceivers ? pc.getTransceivers() : null;
+
       pc.getReceivers().forEach((receiver) => {
-        if (allTracks || receiver.track.kind === 'video') {
-          remoteStream.addTrack(receiver.track);
+        if (!allTracks && receiver.track.kind !== 'video') {
+          return;
         }
+
+        const transceiver = transceivers ? transceivers.find((t: RTCRtpTransceiver) => t.receiver === receiver) : null;
+        const direction = transceiver ? transceiver.currentDirection || transceiver.direction : null;
+
+        if (direction && direction !== 'sendrecv' && direction !== 'recvonly') {
+          return;
+        }
+
+        remoteStream.addTrack(receiver.track);
       });
     }
   }


### PR DESCRIPTION
## Summary

Answering an incoming **video** call **audio-only** had three related defects. Symptom on the caller side: a frozen/black video tile for the callee instead of an audio-call layout — and in some runs the callee's camera turning on without consent.

### 1. The audio-only answer advertised `a=sendrecv` video

`updateDirection()` derived a single answer direction from the first direction attribute in the remote SDP and applied it to **all** transceivers — including the video transceiver that has no local track (the user answered audio-only). The 200 OK therefore claimed `sendrecv` video that would never carry a frame, so the caller's `RTCPeerConnection` surfaced a remote video track and the app rendered a frame-less `<video>` tile.

**Fix:** in the `have-remote-offer` branch, a video transceiver without a local sender track now caps its answer to the receiving part (`sendrecv` → `recvonly`, `sendonly` → `inactive` on hold). Conferences are exempt: the SFU path negotiates track-less `sendrecv` bundles on purpose to allow a later `replaceTrack` upgrade.

With a `recvonly` answer, the caller's video transceiver becomes `sendonly`, no `ontrack` fires, and the UI falls back to the audio layout — while the callee still receives the caller's video.

### 2. Automatic re-INVITEs could silently turn the callee's camera ON (privacy)

On constraint-less reinvites (ICE restart, network change), `reinvite()` derived `shouldDoVideo` from `sessionWantsToDoVideo()` — the **remote** SDP, which advertises video on a video call regardless of what the local user consented to. Result: `getUserMedia({ video: true })`, camera on, frames sent on the m-line bug 1 had negotiated as sending.

**Fix:** derive the decision from local state (`hasLocalVideo()`) instead of the remote SDP. Explicit constraints (video upgrade/downgrade, screenshare) behave as before.

### 3. Phantom receiver tracks counted as "remote video"

`updateRemoteStream()` added **every** `pc.getReceivers()` track to the remote stream, and `hasRemoteVideo()` only checked `kind === 'video' && readyState === 'live'` — true forever for a negotiated receiver that never gets RTP (e.g. our video offer answered `recvonly`, or a peer running an SDK without fix 1).

**Fix:** `updateRemoteStream()` skips receivers whose transceiver is not in a receiving direction (legacy behavior kept when `getTransceivers` is unavailable, e.g. react-native), and `hasRemoteVideo()` additionally requires `!track.muted`. The lax `hasARemoteVideoTrack()` is untouched.

## Notes for reviewers

- No `audioOnly` flag is persisted on the answered session, on purpose: in this SDK `audioOnly` means "deactivate **all** video, even remote" (see `Phone.call()` doc and `wasAudioOnly` in `WebRTCPhone._upgradeToVideo`). Persisting it on an audio answer would stop the callee from *receiving* the caller's video. The trackless-transceiver rule + local-state reinvite decision cover the same need without changing those semantics. For the same reason the fix answers `recvonly` rather than applying `deactivateVideoModifier` (`inactive` would kill inbound video too).
- Behavior change for consumers: `hasRemoteVideo()` / `getRemoteVideoStream()` now report video once the first RTP arrives (remote tracks start muted) rather than as soon as the m-line is negotiated. Apps that decide the layout once at accept time should also re-check on track unmute.

## Tests

- `updateDirection` answer branch: audio-only answer to a video offer (`recvonly`), video answer (`sendrecv` kept), hold (`inactive`), conference exemption (`sendrecv` kept).
- `reinvite`: constraint-less reinvite requests no video without local video, keeps video with local video, follows explicit constraints; `sessionWantsToDoVideo` no longer consulted.
- `hasRemoteVideo`: live-but-muted track ignored; `updateRemoteStream`: non-receiving transceivers skipped, pre-negotiation `direction` fallback, legacy path without `getTransceivers`, `allTracks=false` video-only refresh.

Full suite: 379 tests passing, lint + typecheck clean.