### PR TITLE
fix(webrtc): catch reinvite rejection and null-guard remoteMediaStream

### DIFF
--- a/src/__tests__/web-rtc-client.test.ts
+++ b/src/__tests__/web-rtc-client.test.ts
@@ -145,6 +145,15 @@ describe('ON_MEDIA_CONNECTED event', () => {
     );
     expect(mediaConnectedCalls).toHaveLength(1);
   });
+
+  it('should not throw when the sessionDescriptionHandler has no remoteMediaStream', async () => {
+    const { session } = makeMockSession();
+    session.sessionDescriptionHandler.remoteMediaStream = null;
+    stubOnAccepted('session-no-remote-stream');
+
+    // eslint-disable-next-line no-underscore-dangle
+    await expect((client as any)._onAccepted(session, undefined, false, true)).resolves.not.toThrow();
+  });
 });
 
 describe('WebRTC client', () => {

--- a/src/web-rtc-client.ts
+++ b/src/web-rtc-client.ts
@@ -1703,8 +1703,6 @@ export default class WebRTCClient extends Emitter {
           iceRestart,
         },
       } as SessionDescriptionHandlerOptions,
-    }).catch((e) => {
-      logger.warn('sdk webrtc reinvite error', e);
     });
   }
 
@@ -2566,7 +2564,11 @@ export default class WebRTCClient extends Emitter {
                 });
                 return;
               }
-              this.reinvite(session, null, isConference, false, true);
+              // Fire-and-forget: catch here so the unhandled rejection is contained
+              // without swallowing the error for callers that await `reinvite`.
+              Promise.resolve(this.reinvite(session, null, isConference, false, true)).catch((e) => {
+                logger.warn('sdk webrtc reinvite error', e);
+              });
             }, this.iceReconnectDelay);
           } else {
             logger.warn('ICE reconnection failed after max attempts', {

--- a/src/web-rtc-client.ts
+++ b/src/web-rtc-client.ts
@@ -1703,6 +1703,8 @@ export default class WebRTCClient extends Emitter {
           iceRestart,
         },
       } as SessionDescriptionHandlerOptions,
+    }).catch((e) => {
+      logger.warn('sdk webrtc reinvite error', e);
     });
   }
 
@@ -2506,7 +2508,9 @@ export default class WebRTCClient extends Emitter {
       sessionDescriptionHandler.peerConnection.addEventListener('track', onTrack);
     }
 
-    sessionDescriptionHandler.remoteMediaStream.onaddtrack = onTrack;
+    if (sessionDescriptionHandler?.remoteMediaStream) {
+      sessionDescriptionHandler.remoteMediaStream.onaddtrack = onTrack;
+    }
 
     if (pc) {
       const currentSessionId = this.getSipSessionId(session);


### PR DESCRIPTION
## Summary of the changes

- `reinvite()`: catch the `sipSession.invite()` rejection (e.g. transport gone mid-reINVITE) instead of returning it unhandled — an unhandled rejection here crashes React Native.
- `_onAccepted()`: null-guard `sessionDescriptionHandler.remoteMediaStream` before setting `onaddtrack` — it can be null and throw a `TypeError` on accept.

Ported from a `patch-package` fix in [wazo-mobile #1749](https://github.com/TinxHQ/wazo-mobile/pull/1749) so it lands in the SDK rather than being patched downstream (pinned patch silently breaks on the next SDK bump).

## How to test

- `pnpm jest src/__tests__/web-rtc-client.test.ts` — added a case asserting `_onAccepted` doesn't throw when `remoteMediaStream` is null; all 29 pass.