### PR TITLE
[ITEM-413] fix(websocket): stop reconnecting socket on close when state is CLOSED

### DIFF
--- a/src/__tests__/websocket-client.test.ts
+++ b/src/__tests__/websocket-client.test.ts
@@ -110,4 +110,18 @@ describe('WebSocketClient close', () => {
     expect(socket.close).toHaveBeenCalledWith(1000);
     expect(socket.onmessage).not.toBeNull();
   });
+
+  it('still closes a reconnecting socket whose underlying state is CLOSED', () => {
+    // A ReconnectingWebSocket sits in readyState CLOSED between retries while still reconnecting.
+    // close() must call the inner close() (which stops the retry loop) instead of bailing.
+    const client = makeClient(true);
+    client.connect();
+    const socket = instances[0];
+    socket.readyState = 3;
+
+    client.close(true);
+
+    expect(socket.close).toHaveBeenCalledWith(1000);
+    expect(client.socket).toBeNull();
+  });
 });

--- a/src/websocket-client.ts
+++ b/src/websocket-client.ts
@@ -297,10 +297,10 @@ class WebSocketClient extends Emitter {
       return;
     }
 
-    if (this.socket.readyState === 3) {
-      logger.warn('Trying to close an already closed websocket, bailing.', { url: this._getUrl() });
-      return;
-    }
+    // Do NOT bail when the underlying socket is CLOSED (readyState 3): a ReconnectingWebSocket reports
+    // CLOSED between retry attempts while still actively reconnecting, and only its close() sets
+    // shouldReconnect=false to stop that retry loop. Bailing here left the socket reconnecting forever,
+    // which defeated singleConnection (it orphaned the previous socket on every re-open).
 
     if (force) {
       // Detach inner socket handlers before closing so the dying socket can't fire one last batch


### PR DESCRIPTION
## Summary of the changes

- `WebSocketClient.close()` bailed early when the socket's `readyState === CLOSED`. But a `ReconnectingWebSocket` reports `CLOSED` **between retries while still actively reconnecting**, so bailing left `shouldReconnect=true` and the socket kept retrying forever.
- This orphaned the previous socket on every re-open (re-auth), which **defeated `singleConnection`** (#865): the old socket kept hammering the server in parallel with the new one.
- Fix: don't bail on `CLOSED` — always call the inner `close()`, which sets `shouldReconnect=false` and stops the retry loop. `ReconnectingWebSocket.close()` already no-ops safely on an already-closed underlying socket.

## How to test

- With `singleConnection` on: open/reconnect while a socket is mid-retry during an outage → confirm the previous socket stops retrying (only one live socket remains).
- Unit: `pnpm jest src/__tests__/websocket-client.test.ts` — added a case asserting `close()` still calls the inner `close(1000)` when the underlying state is `CLOSED`.